### PR TITLE
Replace dividend points with more standard shares system

### DIFF
--- a/src/SimpleMarketCollateralMultiParty.sol
+++ b/src/SimpleMarketCollateralMultiParty.sol
@@ -28,6 +28,13 @@ struct Depositor {
 ///         Note: This carries the inherent risk that a malicious executor in collaboration with a malicious
 ///         maker on Bebop could steal user funds by processing a liquidation at a poor price.
 ///
+///         Deposits are indexed with an incrementing value mapped to the depositor.
+///         When the contract's collateral is fully liquidated, the index of the most recent deposit is written to
+///         `lastFullLiquidationDepositIndex` and the `totalShares` is set to 0. Any depositors with a deposit index
+///         less than or equal to `lastFullLiquidationDepositIndex` will have their shares reset to 0.
+///         This ensures that depositors whose collateral has been fully liquidated do not have any remaining ownership
+///         of the contract's collateral when other depositors make new deposits.
+///
 ///         If tokens are sent to the contract by mistake, the borrower can rescue them using the `rescueTokens` function.
 ///         The contract internally tracks the amount of the collateral asset that it has as the difference between the total
 ///         deposited and the total liquidated / withdrawn. If the contract has an excess balance of the collateral asset, it
@@ -102,7 +109,8 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
     event CollateralDeposited(
         address depositor,
         uint256 depositAmount,
-        uint256 sharesMinted
+        uint256 sharesMinted,
+        uint256 depositIndex
     );
     event CollateralReclaimed(
         address reclaimant,
@@ -116,7 +124,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
     );
     event UnderlyingAssetSentToMarket(uint256 amountSent);
     event TokenRescued(address token, uint256 amountRescued);
-    event FullLiquidation();
+    event FullLiquidation(uint32 lastFullLiquidationDepositIndex);
     event LiquidatedSharesReset(address account, uint256 sharesReset);
 
     error BadRescueAttempt(address token);
@@ -263,11 +271,12 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
 
         Depositor storage depositor = _getDepositor(msg.sender);
         depositor.shares += shares;
-        depositor.lastDepositIndex = ++nextDepositIndex;
+        uint32 index = ++nextDepositIndex;
+        depositor.lastDepositIndex = index;
         totalShares += shares;
         availableCollateral += depositAmount;
 
-        emit CollateralDeposited(msg.sender, depositAmount, shares);
+        emit CollateralDeposited(msg.sender, depositAmount, shares, index);
         return true;
     }
 
@@ -410,7 +419,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
         if (availableCollateral == 0) {
             totalShares = 0;
             lastFullLiquidationDepositIndex = nextDepositIndex;
-            emit FullLiquidation();
+            emit FullLiquidation(lastFullLiquidationDepositIndex);
         }
     }
 

--- a/src/SimpleMarketCollateralMultiParty.sol
+++ b/src/SimpleMarketCollateralMultiParty.sol
@@ -189,7 +189,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
         // It is overwritten with the name bytes in the same operation as the length.
         assembly {
             mstore(
-                0x53,
+                0x5b,
                 0x1b57696c64636174436f6c6c61746572616c436f6e74726163745631
             )
             mstore(0x20, 0x20)

--- a/src/SimpleMarketCollateralMultiParty.sol
+++ b/src/SimpleMarketCollateralMultiParty.sol
@@ -43,29 +43,23 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
     uint32 public lastFullLiquidationDepositIndex;
     uint32 public nextDepositIndex;
 
-    // mapping(address account => uint256 shares) public sharesOf;
     mapping(address account => Depositor depositor) internal _depositors;
 
     function _getDepositor(
         address account
     ) internal returns (Depositor storage depositor) {
         depositor = _depositors[account];
-        if (depositor.lastDepositIndex < lastFullLiquidationDepositIndex) {
+        if (depositor.lastDepositIndex <= lastFullLiquidationDepositIndex) {
             emit LiquidatedSharesReset(account, depositor.shares);
             depositor.shares = 0;
             depositor.lastDepositIndex = 0;
         }
     }
 
-    /**
-     * @dev Returns the active shares of an account. Note that once an account
-     *      has withdrawn, this function will return 0 but the `amountDeposited` value
-     *      will still be stored in the `_depositors` mapping for post-withdrawal
-     *      queries about the account's deposited & liquidated collateral.
-     */
+    /// @dev Returns the active shares of an account.
     function sharesOf(address account) public view returns (uint256) {
         Depositor memory depositor = _depositors[account];
-        if (depositor.lastDepositIndex < lastFullLiquidationDepositIndex) {
+        if (depositor.lastDepositIndex <= lastFullLiquidationDepositIndex) {
             return 0;
         }
         return depositor.shares;
@@ -75,7 +69,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
         address account
     ) public view returns (Depositor memory depositor) {
         depositor = _depositors[account];
-        if (depositor.lastDepositIndex < lastFullLiquidationDepositIndex) {
+        if (depositor.lastDepositIndex <= lastFullLiquidationDepositIndex) {
             depositor.shares = 0;
             depositor.lastDepositIndex = 0;
         }
@@ -251,7 +245,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
 
         uint256 depositAmount = _amount.toUint248();
         uint224 shares = (
-            availableCollateral == 0
+            (availableCollateral == 0 || totalShares == 0)
                 ? depositAmount
                 : FixedPointMathLib.fullMulDiv(
                     depositAmount,
@@ -269,7 +263,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
 
         Depositor storage depositor = _getDepositor(msg.sender);
         depositor.shares += shares;
-        depositor.lastDepositIndex = nextDepositIndex++;
+        depositor.lastDepositIndex = ++nextDepositIndex;
         totalShares += shares;
         availableCollateral += depositAmount;
 
@@ -410,7 +404,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
 
         availableCollateral -= collateralLiquidated;
 
-        // If the contract has no available collateral, reset the shares and last liquidation timestamp
+        // If the contract has no available collateral, reset the shares and last liquidated deposit index
         // to avoid inflating the share price of future deposits. Any deposits prior to the last full
         // liquidation will have their shares reset to 0.
         if (availableCollateral == 0) {
@@ -436,6 +430,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
 
         depositor.shares = 0;
         totalShares -= shares;
+        availableCollateral -= reclaimAmount;
 
         collateralAsset.safeTransfer(msg.sender, reclaimAmount);
 

--- a/src/SimpleMarketCollateralMultiParty.sol
+++ b/src/SimpleMarketCollateralMultiParty.sol
@@ -13,8 +13,8 @@ using MathUtils for uint256;
 using SafeCastLib for uint256;
 
 struct Depositor {
-    bool hasReclaimed;
-    uint248 amountDeposited;
+    uint224 shares;
+    uint32 lastDepositIndex;
 }
 
 /// @title SimpleMarketCollateralMultiParty
@@ -28,30 +28,6 @@ struct Depositor {
 ///         Note: This carries the inherent risk that a malicious executor in collaboration with a malicious
 ///         maker on Bebop could steal user funds by processing a liquidation at a poor price.
 ///
-///         As users make deposits, they are assigned shares equivalent to their deposit amounts.
-///         An additional `liquidationPointsCorrection` value is stored for each user to track the
-///         amount of collateral that has been liquidated from their deposit. This functions similarly
-///         to dividends in other DeFi protocols (e.g. Sushi's MasterChef), except that the dividends
-///         are a debit rather than a credit.
-///
-///         Shares can be withdrawn once the underlying market is terminated at a rate of one share per
-///         underlying token, with the amount of collateral liquidated from a particular user's deposit
-///         being subtracted from the share amount. Note that since liquidation points are tracked per-user,
-///         shares returned by the `sharesOf` function are not fungible or even guaranteed to be redeemable.
-///         Users who deposit after a given liquidation will still receive 1 share per collateral token deposited,
-///         but will not be debited for the previous liquidations.
-///
-///         Liquidation points are always rounded up to ensure depositors are never debited less than their proportional
-///         share of liquidated collateral, as that could lead to a situation where the collateral contract is insolvent.
-///         The trade-off is that depositors may be debited a few wei more than they should be, which should be negligible
-///         for all realistic use-cases (i.e. assuming dust of the collateral asset is effectively worthless).
-///
-///         The `getLiquidatedCollateral` function can be used to query the amount of collateral that has been
-///         liquidated from a user's deposit.
-///
-///         The `getReclaimableAmount` function can be used to query the amount of collateral that can be reclaimed
-///         by a user once the market is terminated (assuming no further liquidations occur).
-///
 ///         If tokens are sent to the contract by mistake, the borrower can rescue them using the `rescueTokens` function.
 ///         The contract internally tracks the amount of the collateral asset that it has as the difference between the total
 ///         deposited and the total liquidated / withdrawn. If the contract has an excess balance of the collateral asset, it
@@ -63,13 +39,23 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
     using LibERC20 for address;
     using FunctionTypeCasts for *;
 
-    uint128 internal constant POINTS_MULTIPLIER = type(uint128).max;
-
-    mapping(address account => uint256 liquidationPointsCorrection)
-        public liquidationPointsCorrections;
+    /// @dev The index of the last deposit that was fully liquidated.
+    uint32 public lastFullLiquidationDepositIndex;
+    uint32 public nextDepositIndex;
 
     // mapping(address account => uint256 shares) public sharesOf;
     mapping(address account => Depositor depositor) internal _depositors;
+
+    function _getDepositor(
+        address account
+    ) internal returns (Depositor storage depositor) {
+        depositor = _depositors[account];
+        if (depositor.lastDepositIndex < lastFullLiquidationDepositIndex) {
+            emit LiquidatedSharesReset(account, depositor.shares);
+            depositor.shares = 0;
+            depositor.lastDepositIndex = 0;
+        }
+    }
 
     /**
      * @dev Returns the active shares of an account. Note that once an account
@@ -79,40 +65,26 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
      */
     function sharesOf(address account) public view returns (uint256) {
         Depositor memory depositor = _depositors[account];
-        if (depositor.hasReclaimed) return 0;
-        return depositor.amountDeposited;
+        if (depositor.lastDepositIndex < lastFullLiquidationDepositIndex) {
+            return 0;
+        }
+        return depositor.shares;
     }
 
     function getDepositor(
         address account
-    ) public view returns (bool hasWithdrawn, uint248 amountDeposited) {
-        Depositor memory depositor = _depositors[account];
-        hasWithdrawn = depositor.hasReclaimed;
-        amountDeposited = depositor.amountDeposited;
+    ) public view returns (Depositor memory depositor) {
+        depositor = _depositors[account];
+        if (depositor.lastDepositIndex < lastFullLiquidationDepositIndex) {
+            depositor.shares = 0;
+            depositor.lastDepositIndex = 0;
+        }
     }
-
-    uint256 public liquidationPointsPerShare;
 
     /// @dev The total active (unwithdrawn) shares of the contract.
-    uint248 public totalShares;
-    /// @dev The total amount of shares that have been withdrawn.
-    uint248 public totalWithdrawn;
-    /// @dev The total amount of collateral that has been liquidated.
-    uint248 public totalLiquidated;
-
-    /// @dev The total amount of collateral that has been deposited over
-    ///      the lifetime of the contract.
-    function totalDeposited() public view returns (uint248) {
-        return totalShares + totalWithdrawn;
-    }
-
-    /// @dev Returns the total available collateral of the contract.
-    ///      This is calculated in the contract rather than using the ERC20 balance
-    ///      to ensure the borrower can rescue collateral tokens sent to the contract
-    ///      by mistake.
-    function availableCollateral() public view returns (uint248) {
-        return totalShares - totalLiquidated;
-    }
+    uint224 public totalShares;
+    /// @dev The total amount of collateral that is available to be liquidated or reclaimed.
+    uint256 public availableCollateral;
 
     // factory address that deployed the collateral contract
     address public immutable factory;
@@ -133,11 +105,14 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
 
     uint32 public nextLiquidationTrigger;
 
-    event CollateralDeposited(address depositor, uint256 amountDeposited);
+    event CollateralDeposited(
+        address depositor,
+        uint256 depositAmount,
+        uint256 sharesMinted
+    );
     event CollateralReclaimed(
         address reclaimant,
         uint256 sharesBurned,
-        uint256 liquidatedCollateral,
         uint256 amountReclaimed
     );
     event Liquidation(
@@ -147,6 +122,8 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
     );
     event UnderlyingAssetSentToMarket(uint256 amountSent);
     event TokenRescued(address token, uint256 amountRescued);
+    event FullLiquidation();
+    event LiquidatedSharesReset(address account, uint256 sharesReset);
 
     error BadRescueAttempt(address token);
     error BebopSwapFailed(bytes returnData);
@@ -161,19 +138,9 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
     error ZeroTokenBalance();
     error ZeroShares();
     error ZeroReclaimAmount();
-    error AlreadyReclaimed();
     error ZeroDepositAmount();
     error DivFailed();
-
-    /// When a user makes a deposit, we track the amount of collateral that had already been liquidated as of their deposit
-    /// so as to ensure they are not being penalized for collateral liquidations that occurred previously.
-    function _correctLiquidationPointsForDeposit(
-        address account,
-        uint256 depositAmount
-    ) internal {
-        uint256 liquidationPoints = depositAmount * liquidationPointsPerShare;
-        liquidationPointsCorrections[account] += liquidationPoints;
-    }
+    error InsufficientCollateral();
 
     modifier onlyBorrower() {
         if (msg.sender != marketBorrower) {
@@ -228,7 +195,6 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
         }
     }
 
-    // TODO: Dillon please sanity check this
     function _getCollateralParameters()
         internal
         view
@@ -282,13 +248,32 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
         uint256 _amount
     ) public marketOpen nonReentrant returns (bool) {
         if (_amount == 0) revert ZeroDepositAmount();
-        uint248 amount = _amount.toUint248();
-        collateralAsset.safeTransferFrom(msg.sender, address(this), amount);
-        _depositors[msg.sender].amountDeposited += amount;
-        totalShares += amount;
-        _correctLiquidationPointsForDeposit(msg.sender, amount);
 
-        emit CollateralDeposited(msg.sender, amount);
+        uint256 depositAmount = _amount.toUint248();
+        uint224 shares = (
+            availableCollateral == 0
+                ? depositAmount
+                : FixedPointMathLib.fullMulDiv(
+                    depositAmount,
+                    totalShares,
+                    availableCollateral
+                )
+        ).toUint224();
+        if (shares == 0) revert ZeroShares();
+
+        collateralAsset.safeTransferFrom(
+            msg.sender,
+            address(this),
+            depositAmount
+        );
+
+        Depositor storage depositor = _getDepositor(msg.sender);
+        depositor.shares += shares;
+        depositor.lastDepositIndex = nextDepositIndex++;
+        totalShares += shares;
+        availableCollateral += depositAmount;
+
+        emit CollateralDeposited(msg.sender, depositAmount, shares);
         return true;
     }
 
@@ -308,7 +293,7 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
         uint256 tokenBalance = token.balanceOf(address(this));
         // The collateral asset can only be rescued if the balance is greater than the expected available collateral.
         if (token == collateralAsset) {
-            tokenBalance = tokenBalance.satSub(availableCollateral());
+            tokenBalance = tokenBalance.satSub(availableCollateral);
         }
 
         if (tokenBalance == 0) revert ZeroTokenBalance();
@@ -373,11 +358,14 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
             uint delinquentDebt
         ) = getMarketDelinquencyStatus();
 
-        // Ensure the market is in penalty state and there is no active cooldown
+        // Ensure the market is in penalty state, there is no active cooldown, and
+        // there is enough collateral for the liquidation
         if (!marketInPenalty || delinquentDebt == 0)
             revert MarketNotInPenalty();
         if (block.timestamp < nextLiquidationTrigger)
             revert LiquidationInCooldown();
+        if (maxCollateralToLiquidate > availableCollateral)
+            revert InsufficientCollateral();
 
         // Calculate the maximum repayment amount
         uint maxRepayment = delinquentDebt.bipMul(maxRepaymentBips);
@@ -420,78 +408,55 @@ contract SimpleMarketCollateralMultiParty is ReentrancyGuard {
             underlyingAmountReceived
         );
 
-        /// @dev Update the liquidation points per share to account for the collateral liquidated
-        liquidationPointsPerShare += divUp(
-            collateralLiquidated * POINTS_MULTIPLIER,
-            totalShares
-        );
-        totalLiquidated += collateralLiquidated.toUint248();
+        availableCollateral -= collateralLiquidated;
+
+        // If the contract has no available collateral, reset the shares and last liquidation timestamp
+        // to avoid inflating the share price of future deposits. Any deposits prior to the last full
+        // liquidation will have their shares reset to 0.
+        if (availableCollateral == 0) {
+            totalShares = 0;
+            lastFullLiquidationDepositIndex = nextDepositIndex;
+            emit FullLiquidation();
+        }
     }
 
     function reclaimCollateral() public marketClosed nonReentrant {
-        Depositor storage account = _depositors[msg.sender];
+        Depositor storage depositor = _getDepositor(msg.sender);
 
-        if (account.hasReclaimed) revert AlreadyReclaimed();
+        uint224 shares = depositor.shares;
+        if (shares == 0) revert ZeroShares();
 
-        uint256 _shares = account.amountDeposited;
-        if (_shares == 0) revert ZeroShares();
-
-        uint256 liquidationPoints = (_shares * liquidationPointsPerShare) -
-            liquidationPointsCorrections[msg.sender];
-        uint256 liquidatedCollateral = divUp(
-            liquidationPoints,
-            POINTS_MULTIPLIER
+        uint256 reclaimAmount = FixedPointMathLib.fullMulDiv(
+            shares,
+            availableCollateral,
+            totalShares
         );
-        uint256 reclaimAmount = _shares.satSub(liquidatedCollateral);
 
         if (reclaimAmount == 0) revert ZeroReclaimAmount();
 
-        totalWithdrawn += uint248(_shares);
-        account.hasReclaimed = true;
-        totalShares -= uint248(_shares);
+        depositor.shares = 0;
+        totalShares -= shares;
+
         collateralAsset.safeTransfer(msg.sender, reclaimAmount);
 
-        emit CollateralReclaimed(
-            msg.sender,
-            _shares,
-            liquidatedCollateral,
-            reclaimAmount
-        );
-    }
-
-    /// @dev Returns the total collateral that has been liquidated from an
-    ///      account's deposits. This value is cumulative and is not affected
-    ///      by withdrawals.
-    function getLiquidatedCollateral(
-        address account
-    ) public view returns (uint256) {
-        uint256 _shares = _depositors[account].amountDeposited;
-        if (_shares == 0) return 0;
-
-        uint256 liquidationPoints = (_shares * liquidationPointsPerShare) -
-            liquidationPointsCorrections[account];
-        return divUp(liquidationPoints, POINTS_MULTIPLIER);
+        emit CollateralReclaimed(msg.sender, shares, reclaimAmount);
     }
 
     /// @dev Returns the amount of collateral that can be reclaimed by an
     ///      account. This is the portion of the account's deposited collateral
     ///      that has not been liquidated or withdrawn.
     function getReclaimableAmount(
-        address account
+        address _account
     ) public view returns (uint256) {
-        Depositor memory depositor = _depositors[account];
-        if (depositor.hasReclaimed) return 0;
-
-        uint256 _shares = depositor.amountDeposited;
-        if (_shares == 0) return 0;
-
-        uint256 liquidationPoints = (_shares * liquidationPointsPerShare) -
-            liquidationPointsCorrections[account];
-        uint256 liquidatedCollateral = divUp(
-            liquidationPoints,
-            POINTS_MULTIPLIER
+        uint256 shares = sharesOf(_account);
+        if (shares == 0) return 0;
+        uint256 reclaimAmount = FixedPointMathLib.fullMulDiv(
+            shares,
+            availableCollateral,
+            totalShares
         );
-        return _shares.satSub(liquidatedCollateral);
+
+        return reclaimAmount;
     }
 
     /// @dev Returns `ceil(x / d)`.

--- a/src/WildcatMarketCollateralFactory.sol
+++ b/src/WildcatMarketCollateralFactory.sol
@@ -129,7 +129,7 @@ contract WildcatMarketCollateralFactory {
         // It is overwritten with the name bytes in the same operation as the length.
         assembly {
             mstore(
-                0x53,
+                0x5a,
                 0x1a57696c64636174436F6c6c61746572616c466163746f72795631
             )
             mstore(0x20, 0x20)

--- a/src/WildcatMarketCollateralFactory.sol
+++ b/src/WildcatMarketCollateralFactory.sol
@@ -22,8 +22,13 @@ contract WildcatMarketCollateralFactory {
 
     error CollateralContractAlreadyExists();
 
-    event ExecutorApproved(address indexed executor);
-    event ExecutorRemoved(address indexed executor);
+    event ExecutorApproved(address executor);
+    event ExecutorRemoved(address executor);
+    event CollateralContractCreated(
+        address collateralContract,
+        address collateralToken,
+        address associatedMarket
+    );
 
     error CallerNotArchControllerOwner();
 
@@ -229,6 +234,12 @@ contract WildcatMarketCollateralFactory {
                 _collateralToken,
                 _associatedMarket
             )
+        );
+
+        emit CollateralContractCreated(
+            collateralContract,
+            _collateralToken,
+            _associatedMarket
         );
     }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.20;
 
 import "forge-std/Test.sol";
 import "../src/WildcatMarketCollateralFactory.sol";
-import {WildcatMarketCollateralFactory, LibStoredInitCode, SimpleMarketCollateralMultiParty} from "src/WildcatMarketCollateralFactory.sol";
+import {WildcatMarketCollateralFactory, LibStoredInitCode, SimpleMarketCollateralMultiParty, Depositor} from "src/WildcatMarketCollateralFactory.sol";
 import "v2-protocol/libraries/MathUtils.sol";
 import "solady/tokens/ERC20.sol";
 
@@ -80,11 +80,6 @@ contract BaseTest is Test {
 
     function validateCollateralExpectations() internal view {
         assertEq(
-            expectations.totalDeposited,
-            collateral.totalDeposited(),
-            "totalDeposited mismatch"
-        );
-        assertEq(
             expectations.activeCollateral,
             collateral.availableCollateral(),
             "activeCollateral mismatch"
@@ -92,8 +87,8 @@ contract BaseTest is Test {
         for (uint256 i = 0; i < expectations.depositors.length; i++) {
             address depositor = expectations.depositors[i];
             assertApproxEqAbs(
-                expectations.depositAmounts[depositor],
                 collateral.getReclaimableAmount(depositor),
+                expectations.depositAmounts[depositor],
                 expectations.maxRoundingError[depositor],
                 "depositAmount mismatch"
             );
@@ -163,14 +158,8 @@ contract BaseTest is Test {
         vm.label(address(bebop), "Bebop");
     }
 
-    function _deposit(
-        address account,
-        uint256 amount
-    )
-        internal
-    {
+    function _deposit(address account, uint256 amount) internal {
         uint256 totalShares = collateral.totalShares();
-        uint256 totalDeposited = collateral.totalDeposited();
         uint256 availableCollateral = collateral.availableCollateral();
 
         collateralAsset.mint(account, amount);
@@ -183,7 +172,6 @@ contract BaseTest is Test {
         addDepositor(account, amount);
 
         assertEq(collateral.totalShares(), totalShares + amount);
-        assertEq(collateral.totalDeposited(), totalDeposited + amount);
         assertEq(
             collateral.availableCollateral(),
             availableCollateral + amount,
@@ -235,7 +223,24 @@ contract BaseTest is Test {
         uint256 minUnderlyingOut,
         uint256 underlyingReceived
     ) internal {
-        uint256 totalLiquidated = collateral.totalLiquidated();
+        _fullLiquidation(
+            delinquentAmount,
+            collateralApproved,
+            collateralSpent,
+            minUnderlyingOut,
+            underlyingReceived,
+            false
+        );
+    }
+
+    function _fullLiquidation(
+        uint256 delinquentAmount,
+        uint256 collateralApproved,
+        uint256 collateralSpent,
+        uint256 minUnderlyingOut,
+        uint256 underlyingReceived,
+        bool skipChecks
+    ) internal {
         uint256 availableCollateral = collateral.availableCollateral();
         bytes memory data = _encodeExecute({
             amountIn: collateralSpent,
@@ -285,22 +290,17 @@ contract BaseTest is Test {
         });
 
         assertEq(
-            collateral.totalLiquidated(),
-            totalLiquidated + collateralSpent,
-            "totalLiquidated"
-        );
-        assertEq(
             collateral.availableCollateral(),
             availableCollateral - collateralSpent,
             "availableCollateral"
         );
         subtractLiquidatedCollateral(collateralSpent);
-        validateCollateralExpectations();
+        if (!skipChecks) {
+            validateCollateralExpectations();
+        }
     }
 
     struct StaticValues {
-        uint totalLiquidated;
-        uint totalDeposited;
         uint liquidatedCollateral;
         uint liquidationPointsCorrections;
     }
@@ -310,41 +310,14 @@ contract BaseTest is Test {
         uint256 shares,
         uint256 _liquidatedCollateral,
         uint256 reclaimAmount
-    )
-        internal
-    {
-        StaticValues memory staticValues;
-        staticValues.totalLiquidated = collateral.totalLiquidated();
-        staticValues.totalDeposited = collateral.totalDeposited();
-        staticValues.liquidatedCollateral = collateral.getLiquidatedCollateral(
-            account
-        );
-        staticValues.liquidationPointsCorrections = collateral
-            .liquidationPointsCorrections(account);
-
+    ) internal {
+        Depositor memory depositor = collateral.getDepositor(account);
         uint256 totalShares = collateral.totalShares();
-        uint256 liquidatedCollateral = collateral.getLiquidatedCollateral(
-            account
-        );
-        uint256 totalWithdrawn = collateral.totalWithdrawn();
         uint256 availableCollateral = collateral.availableCollateral();
-        assertEq(
-            liquidatedCollateral,
-            _liquidatedCollateral,
-            "liquidatedCollateral"
-        );
-        (bool hasReclaimed, uint248 amountDeposited) = collateral.getDepositor(
-            account
-        );
 
-        bool willFail = shares == 0 || reclaimAmount == 0 || hasReclaimed;
-        if (hasReclaimed) {
-            vm.expectRevert(
-                abi.encodeWithSelector(
-                    SimpleMarketCollateralMultiParty.AlreadyReclaimed.selector
-                )
-            );
-        } else if (shares == 0) {
+        bool willFail = shares == 0 ||
+            reclaimAmount == 0;
+        if (shares == 0) {
             vm.expectRevert(
                 abi.encodeWithSelector(
                     SimpleMarketCollateralMultiParty.ZeroShares.selector
@@ -363,22 +336,17 @@ contract BaseTest is Test {
             emit SimpleMarketCollateralMultiParty.CollateralReclaimed(
                 account,
                 shares,
-                liquidatedCollateral,
                 reclaimAmount
             );
         }
         vm.prank(account);
         collateral.reclaimCollateral();
+        Depositor memory depositor2 = collateral.getDepositor(account);
         if (!willFail) {
             assertEq(
                 collateral.totalShares(),
                 totalShares - shares,
                 "totalShares not updated"
-            );
-            assertEq(
-                collateral.totalWithdrawn(),
-                totalWithdrawn + reclaimAmount,
-                "totalWithdrawn changed"
             );
             assertEq(collateral.sharesOf(account), 0, "sharesOf changed");
             assertEq(
@@ -387,65 +355,74 @@ contract BaseTest is Test {
                 "getReclaimableAmount not updated"
             );
             assertEq(
-                collateral.getLiquidatedCollateral(account),
-                liquidatedCollateral,
-                "getLiquidatedCollateral changed"
+                depositor2.shares,
+                depositor.shares,
+                "shares not updated"
             );
-            (bool hasReclaimed2, uint248 amountDeposited2) = collateral
-                .getDepositor(account);
-            assertEq(
-                amountDeposited2,
-                amountDeposited,
-                "amountDeposited changed"
-            );
-            assertEq(hasReclaimed2, true, "hasReclaimed not updated");
             assertEq(
                 collateral.availableCollateral(),
                 availableCollateral - reclaimAmount,
                 "availableCollateral not updated"
             );
         }
-        assertEq(
-            collateral.totalLiquidated(),
-            staticValues.totalLiquidated,
-            "totalLiquidated changed"
-        );
-        assertEq(
-            collateral.totalDeposited(),
-            staticValues.totalDeposited,
-            "totalDeposited changed"
-        );
-        assertEq(
-            collateral.getLiquidatedCollateral(account),
-            staticValues.liquidatedCollateral,
-            "liquidatedCollateral changed"
-        );
-        assertEq(
-            collateral.liquidationPointsCorrections(account),
-            staticValues.liquidationPointsCorrections,
-            "liquidationPointsCorrections changed"
-        );
     }
 
     /// @dev Asserts that two values are approximately equal, with the actual value allowed to be greater
     /// than the expected value by a maximum of `delta`
-    function assertApproxEqPlus(uint256 actual, uint256 expected, uint256 delta, string memory err) public {
-        assertGe(actual, expected, string.concat(err, " actual is less than expected"));
-        assertLe(actual, expected + delta, string.concat(err, " actual exceeds expected by more than delta"));
+    function assertApproxEqPlus(
+        uint256 actual,
+        uint256 expected,
+        uint256 delta,
+        string memory err
+    ) public {
+        assertGe(
+            actual,
+            expected,
+            string.concat(err, " actual is less than expected")
+        );
+        assertLe(
+            actual,
+            expected + delta,
+            string.concat(err, " actual exceeds expected by more than delta")
+        );
     }
 
-    function assertApproxEqPlus(uint256 actual, uint256 expected, uint256 delta) public {
+    function assertApproxEqPlus(
+        uint256 actual,
+        uint256 expected,
+        uint256 delta
+    ) public {
         assertApproxEqPlus(actual, expected, delta, "");
     }
 
     /// @dev Asserts that two values are approximately equal, with the actual value allowed to be less
     /// than the expected value by a maximum of `delta`
-    function assertApproxEqMinus(uint256 actual, uint256 expected, uint256 delta, string memory err) public {
-        assertLe(actual, expected, string.concat(err, " actual is greater than expected"));
-        assertGe(actual, expected - delta, string.concat(err, " actual is less than expected by more than delta"));
+    function assertApproxEqMinus(
+        uint256 actual,
+        uint256 expected,
+        uint256 delta,
+        string memory err
+    ) public {
+        assertLe(
+            actual,
+            expected,
+            string.concat(err, " actual is greater than expected")
+        );
+        assertGe(
+            actual,
+            expected - delta,
+            string.concat(
+                err,
+                " actual is less than expected by more than delta"
+            )
+        );
     }
 
-    function assertApproxEqMinus(uint256 actual, uint256 expected, uint256 delta) public {
+    function assertApproxEqMinus(
+        uint256 actual,
+        uint256 expected,
+        uint256 delta
+    ) public {
         assertApproxEqMinus(actual, expected, delta, "");
     }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -19,11 +19,12 @@ using MathUtils for uint256;
 
 struct CollateralExpectations {
     address[] depositors;
-    mapping(address => uint256) depositAmounts;
+    mapping(address => bool) hasDeposited;
+    mapping(address => uint256) shares;
     mapping(address => uint256) liquidatedAmounts;
     // Increase by 1 each time a liquidation is performed
     mapping(address => uint256) maxRoundingError;
-    uint256 totalDeposited;
+    uint256 totalShares;
     uint256 activeCollateral;
 }
 
@@ -41,41 +42,55 @@ contract BaseTest is Test {
 
     function addDepositor(address depositor, uint256 depositAmount) public {
         if (
-            expectations.depositAmounts[depositor] == 0 &&
-            expectations.liquidatedAmounts[depositor] == 0
+            !expectations.hasDeposited[depositor]
         ) {
             expectations.depositors.push(depositor);
+            expectations.hasDeposited[depositor] = true;
         }
-        expectations.depositAmounts[depositor] += depositAmount;
-        expectations.totalDeposited += depositAmount;
+        uint256 shares = expectations.totalShares == 0
+            ? depositAmount
+            : FixedPointMathLib.fullMulDiv(
+                depositAmount,
+                expectations.totalShares,
+                expectations.activeCollateral
+            );
+        expectations.shares[depositor] += shares;
+        expectations.totalShares += shares;
         expectations.activeCollateral += depositAmount;
     }
 
-    function subtractLiquidatedCollateral(uint256 liquidatedCollateral) public {
-        for (uint256 i = 0; i < expectations.depositors.length; i++) {
-            address depositor = expectations.depositors[i];
-            uint256 depositAmount = expectations.depositAmounts[depositor];
-            if (depositAmount > 0) {
-                uint256 proportionalShare = FixedPointMathLib.mulDivUp(
-                    liquidatedCollateral,
-                    depositAmount,
-                    expectations.activeCollateral
-                );
-                expectations.depositAmounts[depositor] = expectations
-                    .depositAmounts[depositor]
-                    .satSub(proportionalShare);
-                expectations.liquidatedAmounts[depositor] += proportionalShare;
-                expectations.maxRoundingError[depositor] += 1;
-            }
+    function getShareValue(address depositor) public view returns (uint256) {
+        uint256 shares = expectations.shares[depositor];
+        if (expectations.totalShares == 0) {
+            return 0;
         }
+        return
+            FixedPointMathLib.fullMulDiv(
+                shares,
+                expectations.activeCollateral,
+                expectations.totalShares
+            );
+    }
+
+    function subtractLiquidatedCollateral(uint256 liquidatedCollateral) public {
         expectations.activeCollateral = expectations.activeCollateral.satSub(
             liquidatedCollateral
         );
+        if (expectations.activeCollateral == 0) {
+            for (uint256 i = 0; i < expectations.depositors.length; i++) {
+                address depositor = expectations.depositors[i];
+                expectations.shares[depositor] = 0;
+            }
+            expectations.totalShares = 0;
+        }
     }
 
     function updateReclaimedCollateral(address depositor) public {
-        expectations.depositAmounts[depositor] = 0;
-        expectations.activeCollateral -= expectations.depositAmounts[depositor];
+        uint256 shares = expectations.shares[depositor];
+        uint256 shareValue = getShareValue(depositor);
+        expectations.activeCollateral -= shareValue;
+        expectations.totalShares -= shares;
+        expectations.shares[depositor] = 0;
     }
 
     function validateCollateralExpectations() internal view {
@@ -86,9 +101,10 @@ contract BaseTest is Test {
         );
         for (uint256 i = 0; i < expectations.depositors.length; i++) {
             address depositor = expectations.depositors[i];
+            uint256 value = getShareValue(depositor);
             assertApproxEqAbs(
                 collateral.getReclaimableAmount(depositor),
-                expectations.depositAmounts[depositor],
+                value,
                 expectations.maxRoundingError[depositor],
                 "depositAmount mismatch"
             );
@@ -171,7 +187,7 @@ contract BaseTest is Test {
         collateral.deposit(amount);
         addDepositor(account, amount);
 
-        assertEq(collateral.totalShares(), totalShares + amount);
+        assertEq(collateral.totalShares(), expectations.totalShares);
         assertEq(
             collateral.availableCollateral(),
             availableCollateral + amount,
@@ -315,8 +331,7 @@ contract BaseTest is Test {
         uint256 totalShares = collateral.totalShares();
         uint256 availableCollateral = collateral.availableCollateral();
 
-        bool willFail = shares == 0 ||
-            reclaimAmount == 0;
+        bool willFail = shares == 0 || reclaimAmount == 0;
         if (shares == 0) {
             vm.expectRevert(
                 abi.encodeWithSelector(
@@ -354,11 +369,7 @@ contract BaseTest is Test {
                 0,
                 "getReclaimableAmount not updated"
             );
-            assertEq(
-                depositor2.shares,
-                depositor.shares,
-                "shares not updated"
-            );
+            assertEq(depositor2.shares, 0, "shares not updated");
             assertEq(
                 collateral.availableCollateral(),
                 availableCollateral - reclaimAmount,

--- a/test/SimpleMarketCollateralMultiParty.invariant.t.sol
+++ b/test/SimpleMarketCollateralMultiParty.invariant.t.sol
@@ -271,7 +271,7 @@ contract SimpleMarketCollateralMultiPartyInvariantTest is BaseTest {
             address depositor = expectations.depositors[i];
             assertApproxEqAbs(
                 collateral.getReclaimableAmount(depositor),
-                expectations.depositAmounts[depositor],
+                getShareValue(depositor),
                 expectations.maxRoundingError[depositor],
                 "Reclaimable amount should match expectations"
             );
@@ -312,7 +312,7 @@ contract SimpleMarketCollateralMultiPartyInvariantTest is BaseTest {
         for (uint256 i = 0; i < expectations.depositors.length; i++) {
             address depositor = expectations.depositors[i];
             uint256 actual = collateral.getReclaimableAmount(depositor);
-            uint256 expected = expectations.depositAmounts[depositor];
+            uint256 expected = getShareValue(depositor);
             assertLe(
                 actual,
                 expected,

--- a/test/SimpleMarketCollateralMultiParty.invariant.t.sol
+++ b/test/SimpleMarketCollateralMultiParty.invariant.t.sol
@@ -4,8 +4,6 @@ pragma solidity >=0.8.20;
 import "./BaseTest.sol";
 
 using MathUtils for uint256;
- 
-
 
 contract CollateralHandler {
     SimpleMarketCollateralMultiParty collateral;
@@ -14,6 +12,26 @@ contract CollateralHandler {
     address executor;
     Vm private vm;
     BaseTest test;
+    uint public ghost_zeroLiquidations;
+
+    mapping(bytes32 => uint256) public calls;
+
+    modifier countCall(bytes32 key) {
+        calls[key]++;
+        _;
+    }
+
+    function callSummary() external view {
+        console.log("Call summary:");
+        console.log("-------------------");
+        console.log("deposit", calls["deposit"]);
+        console.log("liquidateCollateral", calls["liquidateCollateral"]);
+        console.log("reclaimCollateral", calls["reclaimCollateral"]);
+        console.log("fullLiquidate", calls["fullLiquidate"]);
+        console.log("-------------------");
+
+        console.log("Zero liquidations:", ghost_zeroLiquidations);
+    }
 
     constructor(
         SimpleMarketCollateralMultiParty _collateral,
@@ -31,6 +49,10 @@ contract CollateralHandler {
             address(bytes20(uint160(uint256(keccak256("hevm cheat code")))))
         );
     }
+
+    // function closeMarket() public {
+    //     market.setState(100 ether, 100 ether, false, 0, true);
+    // }
 
     function _hem(
         uint256 x,
@@ -83,8 +105,11 @@ contract CollateralHandler {
         }
     }
 
-    function deposit(address depositor, uint256 amount) public {
-        amount = _hem(amount, 0, type(uint104).max);
+    function deposit(
+        address depositor,
+        uint256 amount
+    ) public countCall("deposit") {
+        amount = _hem(amount, 1000, type(uint104).max - 100 ether);
         // Mint tokens to depositor
         collateralAsset.mint(depositor, amount);
         // Approve collateral contract to spend tokens
@@ -97,17 +122,40 @@ contract CollateralHandler {
         test.addDepositor(depositor, amount);
     }
 
+    function fullLiquidate() external countCall("fullLiquidate") {
+        uint availableCollateral = collateral.availableCollateral();
+        if (availableCollateral == 0) {
+            ghost_zeroLiquidations++;
+            return;
+        }
+        liquidateCollateral(
+            availableCollateral,
+            availableCollateral,
+            availableCollateral
+        );
+    }
+
     function liquidateCollateral(
         uint256 delinquentAmount,
         uint256 collateralToLiquidate,
         uint256 underlyingOut
-    ) public {
-        delinquentAmount = _hem(delinquentAmount, 0, type(uint104).max);
+    ) public countCall("liquidateCollateral") {
+        delinquentAmount = _hem(delinquentAmount, 1000, type(uint104).max - 100 ether);
+        if (collateral.nextLiquidationTrigger() > block.timestamp) {
+            vm.warp(collateral.nextLiquidationTrigger() + 1);
+        }
+        uint availableCollateral = collateral.availableCollateral();
+        if (availableCollateral < 1000) {
+            ghost_zeroLiquidations++;
+            return;
+        }
         collateralToLiquidate = _hem(
             collateralToLiquidate,
-            0,
-            collateral.availableCollateral()
+            1000,
+            availableCollateral
         );
+        underlyingOut = _hem(underlyingOut, 1000, delinquentAmount);
+
         // Set market state to delinquent
         market.setState(
             100 ether + delinquentAmount,
@@ -139,22 +187,25 @@ contract CollateralHandler {
         test.subtractLiquidatedCollateral(collateralToLiquidate);
     }
 
-    function reclaimCollateral(address depositor) public {
+    function reclaimCollateral(
+        address depositor
+    ) public countCall("reclaimCollateral") {
+        if (!market.isClosed()) {
+            market.setState(100 ether, 100 ether, false, 0, true);
+        }
         vm.prank(depositor);
         collateral.reclaimCollateral();
         // Update expectations
         test.updateReclaimedCollateral(depositor);
     }
 
-    function rescueTokens(address token) public {
+    function rescueTokens(address token) public countCall("rescueTokens") {
         vm.prank(collateral.marketBorrower());
         collateral.rescueTokens(token);
     }
 }
 
-contract SimpleMarketCollateralMultiPartyInvariantTest is
-    BaseTest
-{
+contract SimpleMarketCollateralMultiPartyInvariantTest is BaseTest {
     CollateralHandler handler;
 
     function setUp() public override {
@@ -170,35 +221,39 @@ contract SimpleMarketCollateralMultiPartyInvariantTest is
         );
 
         // Add handler as target
-        targetContract(address(handler));
 
         // Set target selectors
         bytes4[] memory selectors = new bytes4[](4);
         selectors[0] = CollateralHandler.deposit.selector;
         selectors[1] = CollateralHandler.liquidateCollateral.selector;
         selectors[2] = CollateralHandler.reclaimCollateral.selector;
-        selectors[3] = CollateralHandler.rescueTokens.selector;
-
+        // selectors[3] = CollateralHandler.rescueTokens.selector;
+        selectors[3] = CollateralHandler.fullLiquidate.selector;
         targetSelector(
             FuzzSelector({addr: address(handler), selectors: selectors})
         );
+        targetContract(address(handler));
+    }
+
+    function invariant_callSummary() public {
+        handler.callSummary();
     }
 
     function invariant_totalDepositedMatchesSum() public {
         uint256 sum = 0;
         for (uint256 i = 0; i < expectations.depositors.length; i++) {
             address depositor = expectations.depositors[i];
-            (, uint248 amountDeposited) = collateral.getDepositor(depositor);
-            sum += amountDeposited;
+            Depositor memory _depositor = collateral.getDepositor(depositor);
+            sum += _depositor.shares;
         }
         assertEq(
             sum,
-            expectations.totalDeposited,
+            collateral.totalShares(),
             "Sum of deposits should match total deposited"
         );
         assertEq(
             sum,
-            collateral.totalDeposited(),
+            collateral.totalShares(),
             "Sum of deposits should match contract total deposited"
         );
     }
@@ -209,54 +264,41 @@ contract SimpleMarketCollateralMultiPartyInvariantTest is
             collateral.availableCollateral(),
             "Available collateral should match expectations"
         );
-        assertEq(
-            collateral.totalDeposited() - collateral.totalLiquidated(),
-            collateral.availableCollateral(),
-            "Available collateral should be total deposited minus liquidated"
-        );
     }
 
     function invariant_reclaimableAmounts() public {
         for (uint256 i = 0; i < expectations.depositors.length; i++) {
             address depositor = expectations.depositors[i];
             assertApproxEqAbs(
-                expectations.depositAmounts[depositor],
                 collateral.getReclaimableAmount(depositor),
+                expectations.depositAmounts[depositor],
                 expectations.maxRoundingError[depositor],
                 "Reclaimable amount should match expectations"
             );
         }
     }
 
-    function invariant_totalShares() public {
-        assertEq(
-            collateral.totalShares(),
-            collateral.totalDeposited(),
-            "Total shares should equal total deposited"
-        );
-    }
+    // function invariant_liquidatedCollateralProportional() public {
+    //     uint256 totalLiquidated = expectations.totalDeposited - expectations.activeCollateral;
+    //     if (totalLiquidated == 0) return;
 
-    function invariant_liquidatedCollateralProportional() public {
-        uint256 totalLiquidated = collateral.totalLiquidated();
-        if (totalLiquidated == 0) return;
-
-        for (uint256 i = 0; i < expectations.depositors.length; i++) {
-            address depositor = expectations.depositors[i];
-            uint256 actual = collateral.getLiquidatedCollateral(depositor);
-            uint256 expected = expectations.liquidatedAmounts[depositor];
-            assertGe(
-                actual,
-                expected,
-                "Liquidated collateral should be greater than or equal to expected"
-            );
-            assertApproxEqAbs(
-                actual,
-                expected,
-                1,
-                "Liquidated collateral should be proportional to deposit"
-            );
-        }
-    }
+    //     for (uint256 i = 0; i < expectations.depositors.length; i++) {
+    //         address depositor = expectations.depositors[i];
+    //         uint256 actual = collateral.getLiquidatedCollateral(depositor);
+    //         uint256 expected = expectations.liquidatedAmounts[depositor];
+    //         assertGe(
+    //             actual,
+    //             expected,
+    //             "Liquidated collateral should be greater than or equal to expected"
+    //         );
+    //         assertApproxEqAbs(
+    //             actual,
+    //             expected,
+    //             1,
+    //             "Liquidated collateral should be proportional to deposit"
+    //         );
+    //     }
+    // }
 
     /// INVARIANTS:
     /// 1. No depositor can withdraw more than their deposited amount minus their proportion of
@@ -264,18 +306,18 @@ contract SimpleMarketCollateralMultiPartyInvariantTest is
     /// 2. The sum of all withdrawable amounts should be less than or equal to the total available
     /// collateral.
     function invariant_canNotWithdrawMoreThanAvailable() public {
-        uint256 totalDeposited = collateral.totalDeposited();
+        uint256 totalDeposited = collateral.totalShares();
         if (totalDeposited == 0) return;
         uint256 sumAvailable;
         for (uint256 i = 0; i < expectations.depositors.length; i++) {
             address depositor = expectations.depositors[i];
             uint256 actual = collateral.getReclaimableAmount(depositor);
             uint256 expected = expectations.depositAmounts[depositor];
-            /* assertGe(
+            assertLe(
                 actual,
                 expected,
                 "Reclaimable amount should be <= deposited amount minus liquidated collateral"
-            ); */
+            );
             assertApproxEqAbs(
                 actual,
                 expected,
@@ -289,6 +331,11 @@ contract SimpleMarketCollateralMultiPartyInvariantTest is
             collateral.availableCollateral(),
             "Sum of reclaimable amounts should be <= available collateral"
         );
+        assertLe(
+            sumAvailable,
+            collateralAsset.balanceOf(address(collateral)),
+            "Sum of reclaimable amounts should be <= collateral asset balance"
+        );
         assertApproxEqAbs(
             sumAvailable,
             collateral.availableCollateral(),
@@ -296,4 +343,13 @@ contract SimpleMarketCollateralMultiPartyInvariantTest is
             "Sum of reclaimable amounts should be equal to available collateral within 1 wei per depositor"
         );
     }
+
+    // function invariant_canAlwaysWithdrawWhenClosed() public {
+    //     if (!market.isClosed()) return;
+    //     for (uint256 i = 0; i < expectations.depositors.length; i++) {
+    //         address depositor = expectations.depositors[i];
+
+    //         assertEq(collateral.getReclaimableAmount(depositor), 0, "Reclaimable amount should be 0 when market is closed");
+    //     }
+    // }
 }

--- a/test/SimpleMarketCollateralMultiParty.t.sol
+++ b/test/SimpleMarketCollateralMultiParty.t.sol
@@ -6,7 +6,6 @@ import "./BaseTest.sol";
 using MathUtils for uint256;
 
 contract SimpleMarketCollateralMultiPartyTest is BaseTest {
-
     /* -------------------------------------------------------------------------- */
     /*                              Approve Executors                             */
     /* -------------------------------------------------------------------------- */
@@ -292,8 +291,8 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
         );
         assertEq(
             collateral.sharesOf(address(this)),
-            100 ether,
-            "Shares should be the same"
+            0,
+            "Shares should be burned if collateral contract is fully liquidated"
         );
     }
 
@@ -345,7 +344,8 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
             collateralApproved: 10 ether,
             collateralSpent: 10 ether,
             minUnderlyingOut: 10 ether,
-            underlyingReceived: 10 ether
+            underlyingReceived: 10 ether,
+            skipChecks: true
         });
         assertApproxEqMinus(
             collateral.getReclaimableAmount(address(this)),
@@ -365,17 +365,6 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
             90 ether,
             1,
             "Reclaim amount should be 90 =/- 1 wei"
-        );
-        assertEq(
-            collateral.getLiquidatedCollateral(address(2)),
-            0,
-            "Liquidated collateral should be 0 for new depositor"
-        );
-        assertApproxEqPlus(
-            collateral.getLiquidatedCollateral(address(this)),
-            60 ether,
-            1,
-            "Liquidated collateral should be 60 =/+ 1 wei for old depositor"
         );
     }
 
@@ -498,5 +487,180 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
         vm.expectEmit(address(market));
         emit MockWildcatMarket.Repayment(0, 0);
         collateral.rescueTokens(address(underlyingAsset));
+    }
+
+    function test_violet() external {
+        address userA = address(0x0a);
+        address userB = address(0x0b);
+        address userC = address(0x0c);
+        _deposit(userA, 100 ether);
+        _fullLiquidation({
+            delinquentAmount: 100 ether,
+            collateralApproved: 100 ether,
+            collateralSpent: 100 ether,
+            minUnderlyingOut: 100 ether,
+            underlyingReceived: 100 ether
+        });
+        fastForward(100 days);
+        _deposit(userB, 50 ether);
+        _fullLiquidation({
+            delinquentAmount: 50 ether,
+            collateralApproved: 50 ether,
+            collateralSpent: 50 ether,
+            minUnderlyingOut: 50 ether,
+            underlyingReceived: 50 ether
+        });
+        _deposit(userC, 100 ether);
+        assertApproxEqAbs(
+            collateral.getReclaimableAmount(userA),
+            0,
+            1,
+            "userA should have 0 reclaimable amount"
+        );
+        assertApproxEqAbs(
+            collateral.getReclaimableAmount(userB),
+            0,
+            1,
+            "userB should have 0 reclaimable amount"
+        );
+        assertApproxEqAbs(
+            collateral.getReclaimableAmount(userC),
+            100 ether,
+            1,
+            "userC should have 100 reclaimable amount"
+        );
+        // // _deposit(userC, 100 ether);
+        // Depositor memory depositorA = collateral.getDepositor(userA);
+        // Depositor memory depositorB = collateral.getDepositor(userB);
+        // console.log(
+        //     "userA liquidation points:",
+        //     depositorA.liquidationPointsCorrection
+        // );
+        // console.log(
+        //     "userB liquidation points:",
+        //     depositorB.liquidationPointsCorrection
+        // );
+        // // console.log(
+        // //     "userC liquidation points:",
+        // //     collateral.liquidationPointsCorrections(userC)
+        // // );
+        // console.log(
+        //     "userA liquidated collateral:",
+        //     collateral.getLiquidatedCollateral(userA)
+        // );
+        // console.log(
+        //     "userB liquidated collateral:",
+        //     collateral.getLiquidatedCollateral(userB)
+        // );
+        // console.log(
+        //     "userC liquidated collateral:",
+        //     collateral.getLiquidatedCollateral(userC)
+        // );
+        // console.log(
+        //     "userA reclaimable amount:",
+        //     collateral.getReclaimableAmount(userA)
+        // );
+        // console.log(
+        //     "userB reclaimable amount:",
+        //     collateral.getReclaimableAmount(userB)
+        // );
+        // console.log(
+        //     "userC reclaimable amount:",
+        //     collateral.getReclaimableAmount(userC)
+        // );
+        // console.log("total shares:", collateral.totalShares());
+        // console.log("total liquidated:", collateral.totalLiquidated());
+        // console.log("available collateral:", collateral.availableCollateral());
+    }
+
+    function _doLiquidate(uint collateralToLiquidate) internal returns (uint256) {
+        // delinquentAmount = _hem(delinquentAmount, 1000, type(uint104).max - 100 ether);
+        uint availableCollateral = collateral.availableCollateral();
+        if (availableCollateral < 1000) {
+            return 0;
+        }
+        collateralToLiquidate = _hem(
+            collateralToLiquidate,
+            1000,
+            availableCollateral
+        );
+        console.log("available collateral:", availableCollateral);
+        console.log("liquidation amount:", collateralToLiquidate);
+
+        _fullLiquidation({
+            delinquentAmount: 1 ether,
+            collateralApproved: collateralToLiquidate,
+            collateralSpent: collateralToLiquidate,
+            minUnderlyingOut: 1 ether,
+            underlyingReceived: 1 ether
+        });
+        return collateralToLiquidate;
+    }
+
+    function test_violet2() external {
+        _deposit(10215);
+        uint collateralToLiquidate1 = _doLiquidate(324619612);
+        // Depositor memory depositor = collateral.getDepositor(address(this));
+        // console.log("shares remaining:", depositor.amountDeposited - depositor.amountLiquidated);
+
+        fastForward(100 days);
+        uint collateralToLiquidate2 = _doLiquidate(215013935);
+        // console.log("liquidated 1:", collateralToLiquidate1);
+        // console.log("liquidated 2:", collateralToLiquidate2);
+    }
+
+    /*
+    (4444 * type(uint128).max) / 10215
+    */
+
+    function _hem(
+        uint256 x,
+        uint256 min,
+        uint256 max
+    ) internal pure virtual returns (uint256 result) {
+        require(min <= max, "Max is less than min.");
+        /// @solidity memory-safe-assembly
+        assembly {
+            // prettier-ignore
+            for {} 1 {} {
+                // If `x` is between `min` and `max`, return `x` directly.
+                // This is to ensure that dictionary values
+                // do not get shifted if the min is nonzero.
+                // More info: https://github.com/foundry-rs/forge-std/issues/188
+                if iszero(or(lt(x, min), gt(x, max))) {
+                    result := x
+                    break
+                }
+                let size := add(sub(max, min), 1)
+                if lt(gt(x, 3), gt(size, x)) {
+                    result := add(min, x)
+                    break
+                }
+                if lt(lt(x, not(3)), gt(size, not(x))) {
+                    result := sub(max, not(x))
+                    break
+                }
+                // Otherwise, wrap x into the range [min, max],
+                // i.e. the range is inclusive.
+                if iszero(lt(x, max)) {
+                    let d := sub(x, max)
+                    let r := mod(d, size)
+                    if iszero(r) {
+                        result := max
+                        break
+                    }
+                    result := sub(add(min, r), 1)
+                    break
+                }
+                let d := sub(min, x)
+                let r := mod(d, size)
+                if iszero(r) {
+                    result := min
+                    break
+                }
+                result := add(sub(max, r), 1)
+                break
+            }
+        }
     }
 }

--- a/test/SimpleMarketCollateralMultiParty.t.sol
+++ b/test/SimpleMarketCollateralMultiParty.t.sol
@@ -318,6 +318,7 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
     /// Test that deposits are not penalized for prior liquidations
     function test_depositAfterLiquidation() external {
         _deposit(100 ether);
+        console.log("Step 1");
         _fullLiquidation({
             delinquentAmount: 100 ether,
             collateralApproved: 100 ether,
@@ -325,6 +326,7 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
             minUnderlyingOut: 50 ether,
             underlyingReceived: 51 ether
         });
+        console.log("Step 2");
         assertApproxEqMinus(
             collateral.getReclaimableAmount(address(this)),
             50 ether,
@@ -332,6 +334,7 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
             "Reclaim amount should be 50 =/- 1 wei"
         );
         _deposit(50 ether);
+        console.log("Step 3");
         assertApproxEqMinus(
             collateral.getReclaimableAmount(address(this)),
             100 ether,
@@ -347,6 +350,7 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
             underlyingReceived: 10 ether,
             skipChecks: true
         });
+        console.log("Step 4");
         assertApproxEqMinus(
             collateral.getReclaimableAmount(address(this)),
             90 ether,
@@ -354,6 +358,7 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
             "Reclaim amount should be 90 =/- 1 wei"
         );
         _deposit(address(2), 15 ether);
+        console.log("Step 5");
         assertApproxEqMinus(
             collateral.getReclaimableAmount(address(2)),
             15 ether,
@@ -403,7 +408,7 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
             underlyingReceived: 100 ether
         });
         market.setState(0, 0, false, 0, true);
-        _reclaim(address(this), 100 ether, 100 ether, 0);
+        _reclaim(address(this), 0, 100 ether, 0);
     }
 
     function test_reclaimCollateral_ZeroReclaimAmount_AlreadyReclaimed()
@@ -573,7 +578,33 @@ contract SimpleMarketCollateralMultiPartyTest is BaseTest {
         // console.log("available collateral:", collateral.availableCollateral());
     }
 
-    function _doLiquidate(uint collateralToLiquidate) internal returns (uint256) {
+    function test_invariantResult() external {
+        _deposit(
+            0x760c0c4C0291fDd86F383Dc81A2E563c2090805A,
+            35023802776561736204669
+        );
+        _fullLiquidation({
+            delinquentAmount: 35023802776561736204669,
+            collateralApproved: 35023802776561736204669,
+            collateralSpent: 35023802776561736204669,
+            minUnderlyingOut: 35023802776561736204669,
+            underlyingReceived: 35023802776561736204669
+        });
+        _deposit(0x760c0c4C0291fDd86F383Dc81A2E563c2090805A, 1044352882);
+        uint shares = collateral.sharesOf(
+            0x760c0c4C0291fDd86F383Dc81A2E563c2090805A
+        );
+        uint shares2 = collateral
+            .getDepositor(0x760c0c4C0291fDd86F383Dc81A2E563c2090805A)
+            .shares;
+        assertEq(shares, shares2, "shares not updated");
+        uint totalShares = collateral.totalShares();
+        assertEq(totalShares, shares, "total shares not eq shares");
+    }
+
+    function _doLiquidate(
+        uint collateralToLiquidate
+    ) internal returns (uint256) {
         // delinquentAmount = _hem(delinquentAmount, 1000, type(uint104).max - 100 ether);
         uint availableCollateral = collateral.availableCollateral();
         if (availableCollateral < 1000) {


### PR DESCRIPTION
The points system was broken due to the fact that changes to each account's relative ownership of the vault would only change at the time of their depositing or withdrawing collateral, with no changes to ownership based on the ratio of shares to assets. This made it impossible to accurately track ownership of the underlying collateral in various situations.

This PR removes the dividend-style liquidation points in favor of a more typical shares system where shares are worth proportional amounts of the underlying asset. To deal with the case of deposits after the contract is fully liquidated, the contract tracks a deposit index per account, and writes the most recent deposit index to storage whenever it is fully liquidated, along with setting the total shares to 0. Depositors prior to that have their shares balance reduced to zero. This ensures fully liquidated depositors have no remaining stake in the contract even if new accounts deposit additional assets.

This also updates the tests to account for the changes to the share ownership and to fix a bug in the invariant tests where only one liquidation could happen per run.