### PR TITLE
feat: add attested pro-rata collateral distributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,68 @@
-# Wildcat Market Collateral Contracts
+# Wildcat market collateral contracts
 
-Smart contracts for managing credit line collateral within the Wildcat protocol. This implementation provides a mechanism for borrowers to deposit collateral that can be liquidated in case of delinquency.
+Smart contracts for holding collateral against Wildcat credit markets and liquidating it when a
+market enters penalised delinquency.
 
-## Overview
+## What is here
 
-This repository contains Solidity smart contracts for collateral management in Wildcat markets:
+- `WildcatMarketCollateralFactory` deploys collateral contracts with deterministic addresses.
+- `SimpleMarketCollateral` supports borrower-owned collateral for one market.
+- `SimpleMarketCollateralMultiParty` supports collateral deposits from many accounts and tracks each
+  depositor's share of later liquidations.
+- `docs/pro-rata-collateral-snapshots.md` sketches the pro-rata collateral release prototype being
+  explored in issue [#5](https://github.com/wildcat-finance/collateral-contract/issues/5).
 
-- `WildcatMarketCollateral`: Core contract for collateral management
-- `WildcatMarketCollateralFactory`: Factory contract for deploying collateral contracts
-- `SimpleMarketCollateral`: Simplified collateral implementation
-- `SimpleMarketCollateralMultiParty`: Multi-party collateral implementation
+## Multi-party collateral
 
-## SimpleMarketCollateralMultiParty
+`SimpleMarketCollateralMultiParty` lets many users deposit one collateral asset for a Wildcat market.
+Approved liquidators can sell collateral through Bebop PMM when the market is in penalised
+delinquency, then send the received underlying asset to the market as repayment.
 
-The `SimpleMarketCollateralMultiParty` contract is the core collateral management system designed for Wildcat markets with these key features:
+The contract tracks deposits with shares and tracks liquidation debits with a points-style accounting
+system. A depositor who enters after a liquidation is not charged for that earlier liquidation. When
+the market is closed, each depositor can reclaim its remaining collateral.
 
-### Purpose and Design
-A collateral contract that supports multiple depositors providing collateral assets that can be liquidated when the underlying Wildcat market enters a penalized delinquency state. The contract integrates with Bebop PMM (Private Market Maker) for efficient liquidation processing.
+The current implementation does not support rebasing tokens or assets with non-standard transfer
+semantics because it uses internal accounting rather than treating `balanceOf(address(this))` as the
+source of truth. Tokens sent by mistake can be rescued by the borrower when the rescue does not
+touch committed collateral.
 
-### Key Functionality
+## Factory
 
-- **Multi-Party Deposit System**: Allows multiple users to deposit collateral assets while maintaining individual accounting.
-- **Share-Based Accounting**: Users receive shares equivalent to their deposit amounts, with internal accounting to track liquidations.
-- **Liquidation Management**: Liquidations are processed through Bebop PMM by approved liquidators when markets enter penalized delinquency.
-- **Liquidation Points**: Utilizes a dividend-like system (but for debits) to track the amount of collateral liquidated from each user's deposit.
-- **Fair Distribution**: New depositors are not penalized for liquidations that occurred before their deposits.
-- **Reclaim Mechanism**: Users can withdraw their remaining collateral once the underlying market is terminated.
-- **Token Rescue**: Borrowers can rescue tokens mistakenly sent to the contract.
+`WildcatMarketCollateralFactory` deploys collateral contracts with CREATE2. The deployment salt is
+based on the collateral token and the associated market, so a market can have one collateral contract
+per collateral asset. During deployment, the factory stores the borrower, collateral token and market
+in transient storage for the collateral contract constructor.
 
-### Deployment through WildcatMarketCollateralFactory
+The factory also lets the Wildcat arch-controller owner approve and remove liquidators.
 
-The `WildcatMarketCollateralFactory` is responsible for deploying `SimpleMarketCollateralMultiParty` contracts using these key mechanisms:
+## Known risks
 
-- **Deterministic Deployment**: Uses Create2 for deterministic address generation, ensuring contracts can be located predictably.
-- **Collateral Parameters**: Temporarily stores parameters (collateral token, associated market, borrower) in transient storage during deployment.
-- **Deployment Process**:
-  1. Market participants call `deployCollateralContract(collateralToken, associatedMarket)`
-  2. Factory creates a unique salt based on the collateral token and associated market
-  3. Factory verifies no duplicate contract exists for the same parameters
-  4. Factory retrieves the borrower from the associated market
-  5. Parameters are temporarily stored for the contract constructor to access
-  6. Contract is deployed using LibStoredInitCode for efficient deployment
-  7. Deployed contract is registered in the factory's tracking system
-
-- **Contract Registry**: Maintains a mapping of deployed collateral contracts by market, allowing query functions like `listCollateralMarkets(market, asset)`
-- **Liquidator Management**: Provides functions to approve and remove liquidators who can execute collateral liquidations
-
-### Security Considerations
-
-- The liquidation process carries an inherent risk where a malicious executor collaborating with a malicious maker on Bebop could potentially process liquidations at unfavorable prices.
-- The contract does not support rebasing tokens or assets with non-standard transfer semantics due to its internal balance tracking approach.
-- Liquidations are restricted by cooldown periods and maximum repayment limits to prevent abuse.
-
-### Key Functions
-
-- `deposit(uint256 _amount)`: Allows users to deposit collateral
-- `liquidateCollateral(bytes, uint, uint, uint)`: Sells collateral to repay delinquent debt via Bebop PMM
-- `reclaimCollateral()`: Allows users to reclaim their remaining collateral after market termination
-- `getLiquidatedCollateral(address)`: Returns the total collateral that has been liquidated from an account
-- `getReclaimableAmount(address)`: Returns the amount of collateral that can be reclaimed by an account
+- Liquidation depends on calldata supplied to Bebop PMM by an approved executor. A malicious executor
+  and maker could sell collateral at a poor price.
+- Cooldowns and maximum repayment checks limit liquidation cadence and over-repayment, but they do
+  not make the swap price fair.
+- Multi-party accounting rounds liquidation points up so the contract does not become insolvent. A
+  depositor can be debited a few wei more than its exact proportional share.
+- The repo contains a commented historical `WildcatMarketCollateral.sol`; current tests target
+  `SimpleMarketCollateralMultiParty`.
 
 ## Development
 
-This project uses [Foundry](https://book.getfoundry.sh/) for Ethereum development.
-
-### Setup
+This project uses Foundry.
 
 ```shell
-# Clone the repository with submodules
 git clone --recursive https://github.com/wildcat-finance/collateral-contract.git
 cd collateral-contract
-
-# Install dependencies
-forge install
-```
-
-### Build
-
-```shell
-forge build
-```
-
-### Test
-
-```shell
 forge test
 ```
 
-### Code Coverage
+Coverage:
 
 ```shell
 yarn coverage
 ```
 
-## License
+## Licence
 
 Apache-2.0 WITH LicenseRef-Commons-Clause-1.0

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -10,3 +10,28 @@ Leads not pursued: Fizz was not run because step 1 ships no Solidity. The x-ray 
 ran, but its nSLOC helper attempted `grep -P`, which macOS grep does not support; source enumeration
 completed and nSLOC was recomputed manually as 1,305. `forge test --summary` passed 35/35 after the
 docs changes. `hexaemeron:imprimatur` scored the touched prose at 100/100.
+
+## Step 2, round 1 -- 2026-08-17
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| PRD-01 | high | `src/ProRataCollateralDistributor.sol` | `finalizeSnapshot` froze `totalCollateral` from the current token balance. An unprivileged caller could finalise after the review delay while the distributor was unfunded or underfunded, causing later collateral to be excluded from claims and swept as dust after claims completed. | fixed |
+| PRD-02 | medium | `src/ProRataCollateralDistributor.sol` | `finalizeSnapshot` was public, so a claimant could front-run an authority cancellation at the review deadline and permanently finalise a bad pending root. | fixed |
+
+Fixes:
+
+- `SnapshotProposal` now commits to `collateralAmount`.
+- `proposeSnapshot` rejects a zero collateral amount.
+- `finalizeSnapshot` is authority-only.
+- `finalizeSnapshot` requires the distributor balance to cover the proposed collateral amount before finalisation.
+- `totalCollateral` is frozen from the proposed collateral amount, not from whatever balance happens to be present.
+
+Verification after fixes:
+
+- `forge test --match-contract ProRataCollateralDistributorTest --summary`: 9 passed, 0 failed.
+- `forge test --summary`: 44 passed, 0 failed, 0 skipped.
+- `git diff --check`: clean.
+- Math, access and state-flow re-checks reported no remaining concrete findings. Residual leads are
+  authority/evidence-process risks: the root total must match the leaf sum, leaves are portable if an
+  authority reuses a root in the wrong domain, and non-standard collateral tokens can still create
+  operational accounting surprises.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1,0 +1,12 @@
+# Audit log
+
+## Step 1, round 1 -- 2026-08-16
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| none | none | docs / README | Docs-only step reviewed against the pro-rata collateral snapshot risk register; no Solidity changed and no security finding was identified. | closed |
+
+Leads not pursued: Fizz was not run because step 1 ships no Solidity. The x-ray enumeration script
+ran, but its nSLOC helper attempted `grep -P`, which macOS grep does not support; source enumeration
+completed and nSLOC was recomputed manually as 1,305. `forge test --summary` passed 35/35 after the
+docs changes. `hexaemeron:imprimatur` scored the touched prose at 100/100.

--- a/docs/fiat/pro-rata-collateral-runbook.md
+++ b/docs/fiat/pro-rata-collateral-runbook.md
@@ -29,9 +29,10 @@ snapshot and distribute collateral by Merkle-proven scaled-debt proportions.
 **Entry.** Step 1 branch after its PR commit.
 
 **Exit.** The distributor supports one collateral asset and one market per instance; a snapshot
-authority can propose a root with `market`, `snapshotBlock`, `totalScaledDebt`, `merkleRoot`,
-`evidenceHash` and `reviewEndsAt`; the authority can cancel before finalisation; anyone can finalise
-after the review delay; each account can claim once with a Merkle proof. Claimed amounts are
+authority can propose a root with `market`, `snapshotBlock`, `totalScaledDebt`,
+`collateralAmount`, `merkleRoot`, `evidenceHash` and `reviewEndsAt`; the authority can cancel before
+finalisation; the authority can finalise after the review delay once the distributor holds the
+committed collateral amount; each account can claim once with a Merkle proof. Claimed amounts are
 calculated as `floor(totalCollateral * scaledDebt / totalScaledDebt)`, and a deterministic dust path
 prevents permanent accounting ambiguity.
 

--- a/docs/fiat/pro-rata-collateral-runbook.md
+++ b/docs/fiat/pro-rata-collateral-runbook.md
@@ -1,0 +1,68 @@
+# Runbook: pro-rata collateral release snapshots
+
+## Step 1: Commit the spec and user-facing framing
+
+**Goal.** Commit the completed Fiat study and runbook so reviewers can judge the idea before
+reading prototype code.
+
+**Entry.** `main` at `d2f370963957eca2d5f72aa618e22ebf82ccddbe`, with `.hexaemeron/study.md`
+receipted by the controller.
+
+**Exit.** A committed docs page describes the problem, chosen design, non-goals and risk register
+for attested pro-rata collateral release. The private `.hexaemeron/runbook.md` and
+`.hexaemeron/study.md` are copied into tracked docs after the prose pass.
+
+**Files.**
+
+- `docs/pro-rata-collateral-snapshots.md`
+- `docs/fiat/pro-rata-collateral-study.md`
+- `docs/fiat/pro-rata-collateral-runbook.md`
+
+**Tests.** Run `forge test --summary` to prove no code behaviour changed. Run the prose lint on the
+new docs.
+
+## Step 2: Add the attested collateral distributor
+
+**Goal.** Add a minimal `ProRataCollateralDistributor` that can finalise an authenticated debt
+snapshot and distribute collateral by Merkle-proven scaled-debt proportions.
+
+**Entry.** Step 1 branch after its PR commit.
+
+**Exit.** The distributor supports one collateral asset and one market per instance; a snapshot
+authority can propose a root with `market`, `snapshotBlock`, `totalScaledDebt`, `merkleRoot`,
+`evidenceHash` and `reviewEndsAt`; the authority can cancel before finalisation; anyone can finalise
+after the review delay; each account can claim once with a Merkle proof. Claimed amounts are
+calculated as `floor(totalCollateral * scaledDebt / totalScaledDebt)`, and a deterministic dust path
+prevents permanent accounting ambiguity.
+
+**Files.**
+
+- `src/ProRataCollateralDistributor.sol`
+- `src/interfaces/IProRataCollateralDistributor.sol`
+- `test/ProRataCollateralDistributor.t.sol`
+
+**Tests.** Add unit tests for constructor validation, proposal, cancellation, finalisation delay,
+bad proof rejection, double-claim rejection, pro-rata claims, dust handling and zero-total-debt
+rejection. Run `forge test --summary`.
+
+## Step 3: Add observability hooks and the end-to-end demo
+
+**Goal.** Show how a reconciler gets the data it needs without changing the Wildcat market token.
+
+**Entry.** Step 2 branch after its PR commit.
+
+**Exit.** Add a small recorder/mock hook surface that emits scaled debt movements for deposits,
+transfers and queued withdrawals, plus an end-to-end test that reconstructs a simple snapshot from
+known balances, finalises the distributor and releases collateral to multiple debt holders. The demo
+must show the lag explicitly: event trail, proposed root, review delay, finalisation, claims.
+
+**Files.**
+
+- `src/DebtSnapshotEventRecorder.sol`
+- `src/interfaces/IDebtSnapshotEventRecorder.sol`
+- `test/DebtSnapshotEventRecorder.t.sol`
+- `test/ProRataCollateralReleaseDemo.t.sol`
+- `docs/pro-rata-collateral-snapshots.md`
+
+**Tests.** Add tests for emitted scaled movement events and the full demo path. Run
+`forge test --summary`.

--- a/docs/fiat/pro-rata-collateral-study.md
+++ b/docs/fiat/pro-rata-collateral-study.md
@@ -1,0 +1,215 @@
+# Study: pro-rata collateral release snapshots
+
+## Problem statement
+
+Build a prototype for physical-style collateral release when a Wildcat market has many debt
+holders and collateral should be divided by debt ownership at a chosen settlement point.
+
+The user story is a BTC-backed USDC facility where, after a default or other agreed trigger, the
+remaining BTC collateral can be released to debt holders pro rata instead of forcing an AMM sale.
+The hard part is not the division formula. The hard part is recording who owned what share of the
+Wildcat debt at the settlement point without changing the market token into a bespoke ERC-20.
+
+For this run, “working prototype” means:
+
+1. a small contract can accept an authenticated snapshot of debt-holder proportions for a market;
+2. the snapshot can be finalised after a review delay;
+3. collateral held by the distributor can be claimed once per account using those proportions; and
+4. tests show that the full collateral pool is allocated by the committed proportions, with dust
+   handled deterministically.
+
+The prototype does not need to be fully trustless. It must make the trust boundary explicit enough
+that a later design can replace the reconciler with a stronger attestation or proof system.
+
+Tracking issue: <https://github.com/wildcat-finance/collateral-contract/issues/5>.
+
+## Prior art
+
+### In this repository
+
+- `src/SimpleMarketCollateralMultiParty.sol` already implements the inverse accounting problem:
+  several collateral depositors supply one collateral pool, liquidation debits are assigned by
+  per-share points, and post-termination `reclaimCollateral()` returns each depositor's remaining
+  collateral.
+- `src/SimpleMarketCollateral.sol` is the borrower-only version. It sells collateral through Bebop
+  and sends the underlying asset to the Wildcat market.
+- `src/WildcatMarketCollateralFactory.sol` deploys `SimpleMarketCollateralMultiParty` with
+  borrower, market and collateral parameters pulled from transient storage.
+- `test/SimpleMarketCollateralMultiParty.t.sol` and
+  `test/SimpleMarketCollateralMultiParty.invariant.t.sol` give the current unit and invariant
+  style. Baseline command run during study: `forge test --summary`, 35 passed, 0 failed.
+
+The existing multi-party collateral accounting is useful because it already treats “fairness” as a
+points problem rather than an array of holders problem. The new feature runs in the other direction:
+split collateral among debt holders, not among collateral providers.
+
+### In `v2-protocol`
+
+The submodule is pinned at `f5c39bcd224c558d18cb53568c785efac0db0835`.
+
+- `lib/v2-protocol/src/market/WildcatMarketToken.sol` implements ERC-20 actions for market tokens.
+  `balanceOf(account)` returns a normalised balance by applying the current `scaleFactor`, while
+  `scaledBalanceOf(account)` returns the stored scaled claim.
+- `WildcatMarketToken._transfer()` converts the requested normalised transfer amount into
+  `scaledAmount`, calls the configured hook, then mutates sender and recipient scaled balances and
+  emits a normal ERC-20 `Transfer` event with the requested normalised amount.
+- `lib/v2-protocol/src/market/WildcatMarketBase.sol` exposes `scaledTotalSupply()` and
+  `scaleFactor()`. The market also emits ERC-20 `Transfer` events when withdrawal batch payments
+  burn debt.
+- `lib/v2-protocol/src/access/IHooks.sol` and `lib/v2-protocol/src/types/HooksConfig.sol` show that
+  a market can enable `onDeposit`, `onTransfer`, `onQueueWithdrawal`, `onExecuteWithdrawal`, and
+  other callbacks, but a deployed market has one hooks configuration.
+
+Those facts matter because ERC-20 `Transfer` events alone are not a complete proportional ledger for
+an interest-bearing Wildcat claim. The scaled balance is the durable claim unit. A hook can see
+`scaledAmount`, but only markets deployed with such a hook from inception can get an onchain transfer
+trail without protocol changes.
+
+### Standards and external references
+
+- EIP-20 defines the standard token API and `Transfer` event. The prototype should avoid changing
+  market-token transfer semantics or relying on non-standard token behaviour:
+  <https://eips.ethereum.org/EIPS/eip-20>.
+- EIP-4626 defines tokenised vault shares over one ERC-20 asset. A wrapper/vault design is relevant
+  when a single controlled wrapper owns the Wildcat debt and users hold wrapper shares:
+  <https://eips.ethereum.org/EIPS/eip-4626>.
+
+## Constraints and non-goals
+
+- Starting point: `wildcat-finance/collateral-contract` `main` at
+  `d2f370963957eca2d5f72aa618e22ebf82ccddbe`.
+- Toolchain: Foundry, Solidity `>=0.8.20`; compilation currently uses solc `0.8.28`.
+- The repo is Apache-2.0 WITH LicenseRef-Commons-Clause-1.0.
+- Do not merge automatically. The output must be branch and PR only.
+- Do not mutate Wildcat market token ERC-20 behaviour.
+- Do not assume onchain access to historical balances. The EVM cannot ask a contract what
+  `scaledBalanceOf(account)` was at an old block unless that contract recorded the value.
+- Do not build an AMM or liquidation router in this prototype.
+- Do not solve BTC price observation, BRC option payoff, liquidation eligibility, sanctions escrow
+  handling, or legal classification in this repo.
+- Do not claim the snapshot source is trustless if it is an attested offchain reconciliation.
+
+## Design options
+
+### Option A: Merkle snapshot distributor with attested root
+
+A `ProRataCollateralDistributor` holds collateral for one market. A snapshot authority proposes:
+
+- market;
+- collateral asset;
+- snapshot block or settlement timestamp;
+- total scaled debt in the snapshot;
+- Merkle root of `(account, scaledDebt)` leaves; and
+- evidence hash for the reconciliation bundle.
+
+After a review delay, the root can be finalised. Each account claims collateral with a Merkle proof.
+The claim amount is `floor(totalCollateral * scaledDebt / totalScaledDebt)`, with the last claim or
+an explicit dust recipient handling remainder.
+
+Trade: simplest useful prototype, no ERC-20 changes, works with existing markets if the authority
+can reconstruct holders. The cost is trust in the authority or ratifier set. A challenge path can
+pause or replace bad roots, but it cannot verify arbitrary historical balances onchain without more
+machinery.
+
+### Option B: live onchain scaled-balance tracker hook
+
+A hooks template updates a mapping on `onDeposit`, `onTransfer` and `onQueueWithdrawal`, tracking
+current scaled claims for every lender. Settlement freezes that mapping and a collateral distributor
+uses it.
+
+Trade: stronger data, weaker deployability. It only works for markets deployed with the tracker hook
+from the start, costs gas on each transfer path, needs careful coverage of deposits, withdrawals,
+force-buybacks, sanctions flows and market closure, and competes with existing hooks because a market
+has one hooks configuration.
+
+### Option C: ERC-4626-style fixed-supply wrapper
+
+A wrapper or vault owns the Wildcat debt. Users hold wrapper shares, and physical settlement divides
+collateral by wrapper shares at settlement.
+
+Trade: clean for new structured products, poor for general markets. It solves holder enumeration by
+making the wrapper the only market lender, but it changes the product shape and does not help an
+ordinary multi-lender Wildcat market after the fact.
+
+### Option D: mutate the debt token into a checkpointed token
+
+Add checkpoints or per-block holder accounting to the Wildcat market token itself.
+
+Trade: strongest direct source if done perfectly, but the wrong prototype. It expands protocol audit
+surface, changes ERC-20 expectations, and forces all markets to pay for a feature only some
+collateral products need.
+
+## Picked design
+
+Pick Option A first: an attested Merkle snapshot distributor.
+
+It is the cheapest construction that proves whether the product idea is useful. It keeps Wildcat
+market tokens standard, avoids AMM sale pressure, and makes the offline reconciliation lag explicit:
+settlement can wait a few hours while an indexer and ratifiers produce the root. If the prototype is
+useful, Option B can be added later as a stronger source for markets launched with a tracker hook.
+
+The study reading of the user's idea is:
+
+- use events and optional hooks to improve observability;
+- use an offchain reconciler because historic holder sets are not enumerable onchain;
+- commit the reconciled result onchain before collateral release; and
+- accept a delay/challenge window as part of the physical-settlement product.
+
+## Risk register seed
+
+- **Snapshot authority.** A bad root can redirect collateral. The first prototype must name the
+  proposer/admin role and provide at least a review delay and cancellation path.
+- **Historical truth.** Onchain contracts cannot verify old `scaledBalanceOf` values for arbitrary
+  accounts. Any claim of truth must come from a committed data bundle, multiple ratifiers, a tracker
+  hook deployed from inception, or a proof system not built in step 1.
+- **Scaled versus normalised debt.** Wildcat market tokens accrue through `scaleFactor`. Settlement
+  proportions should use scaled debt unless the product deliberately wants time-of-snapshot
+  normalised balances.
+- **Withdrawal state.** Debt queued into withdrawal batches may no longer be an active market-token
+  balance but may still be an unpaid claim. A real release rule must decide whether the snapshot
+  includes active balances only, unpaid withdrawal claims, or both.
+- **Dust and rounding.** `floor(totalCollateral * accountDebt / totalDebt)` leaves remainder. The
+  contract needs deterministic dust handling and tests over small numbers.
+- **Double claim.** Each leaf/account must be claimable once.
+- **Collateral custody.** The distributor must not let borrower/admin rescue committed collateral
+  after finalisation.
+- **Reorg and lag.** A snapshot block should have enough confirmations before the root is proposed.
+  The review delay is a product feature, not a bug.
+- **Sanctions and blocked recipients.** This repo already interacts with Wildcat markets. A later
+  production design must decide whether claim recipients can be blocked, escrowed or redirected.
+- **Upgrade/admin risk.** Any mutable root or authority must be frozen once finalised.
+
+## Glossary seeds
+
+- **Snapshot block:** the block whose debt-holder proportions control collateral release.
+- **Scaled debt:** Wildcat claim units before applying `scaleFactor`; durable for proportional
+  accounting.
+- **Normalised debt:** user-facing balance after applying `scaleFactor`; useful for display, not the
+  first-choice settlement unit.
+- **Reconciler:** offchain process that reconstructs holder proportions and prepares the snapshot
+  bundle.
+- **Snapshot authority:** onchain role allowed to propose or cancel roots.
+- **Evidence hash:** digest of the reconciliation bundle, source ranges and tool outputs.
+- **Review delay:** time between root proposal and finalisation.
+- **Claim leaf:** encoded `(account, scaledDebt)` entry in the Merkle tree.
+- **Dust:** collateral remainder caused by integer division.
+- **Physical-style settlement:** distributing the collateral asset itself instead of selling it for
+  the market's underlying asset.
+
+## Sources
+
+- `README.md`
+- `foundry.toml`
+- `package.json`
+- `src/SimpleMarketCollateralMultiParty.sol`
+- `src/SimpleMarketCollateral.sol`
+- `src/WildcatMarketCollateralFactory.sol`
+- `test/SimpleMarketCollateralMultiParty.t.sol`
+- `test/SimpleMarketCollateralMultiParty.invariant.t.sol`
+- `test/BaseTest.sol`
+- `lib/v2-protocol/src/market/WildcatMarketToken.sol`
+- `lib/v2-protocol/src/market/WildcatMarketBase.sol`
+- `lib/v2-protocol/src/access/IHooks.sol`
+- `lib/v2-protocol/src/types/HooksConfig.sol`
+- EIP-20: <https://eips.ethereum.org/EIPS/eip-20>
+- EIP-4626: <https://eips.ethereum.org/EIPS/eip-4626>

--- a/docs/fiat/pro-rata-collateral-study.md
+++ b/docs/fiat/pro-rata-collateral-study.md
@@ -13,7 +13,7 @@ Wildcat debt at the settlement point without changing the market token into a be
 For this run, “working prototype” means:
 
 1. a small contract can accept an authenticated snapshot of debt-holder proportions for a market;
-2. the snapshot can be finalised after a review delay;
+2. the snapshot authority can finalise the snapshot after a review delay;
 3. collateral held by the distributor can be claimed once per account using those proportions; and
 4. tests show that the full collateral pool is allocated by the committed proportions, with dust
    handled deterministically.
@@ -99,12 +99,14 @@ A `ProRataCollateralDistributor` holds collateral for one market. A snapshot aut
 - collateral asset;
 - snapshot block or settlement timestamp;
 - total scaled debt in the snapshot;
+- committed collateral amount;
 - Merkle root of `(account, scaledDebt)` leaves; and
 - evidence hash for the reconciliation bundle.
 
-After a review delay, the root can be finalised. Each account claims collateral with a Merkle proof.
-The claim amount is `floor(totalCollateral * scaledDebt / totalScaledDebt)`, with the last claim or
-an explicit dust recipient handling remainder.
+After a review delay, the snapshot authority can finalise the root once the distributor holds the
+committed collateral amount. Each account claims collateral with a Merkle proof. The claim amount is
+`floor(totalCollateral * scaledDebt / totalScaledDebt)`, with the last claim or an explicit dust
+recipient handling remainder.
 
 Trade: simplest useful prototype, no ERC-20 changes, works with existing markets if the authority
 can reconstruct holders. The cost is trust in the authority or ratifier set. A challenge path can

--- a/docs/pro-rata-collateral-snapshots.md
+++ b/docs/pro-rata-collateral-snapshots.md
@@ -31,9 +31,11 @@ or an explicit decision to use another unit.
 The first prototype is an attested Merkle snapshot distributor.
 
 1. A reconciler reconstructs debt-holder proportions for a market and snapshot point.
-2. A snapshot authority proposes a Merkle root, total scaled debt and evidence hash.
+2. A snapshot authority proposes a Merkle root, total scaled debt, collateral amount and evidence
+   hash.
 3. The proposal waits through a review delay.
-4. The root is finalised.
+4. The snapshot authority finalises the root once the distributor holds the committed collateral
+   amount.
 5. Each account claims collateral once with a Merkle proof.
 
 This is not trustless. The point of v0 is to make the trust boundary small and visible. A later
@@ -62,7 +64,8 @@ data trail without changing ERC-20 behaviour.
 - scaled debt versus normalised debt;
 - double claims;
 - rounding dust;
-- admin cancellation and finalisation timing; and
+- admin cancellation and finalisation timing;
+- underfunded finalisation; and
 - collateral rescue after commitment.
 
 The design is promising only if those risks stay explicit. If the product copy starts saying “the

--- a/docs/pro-rata-collateral-snapshots.md
+++ b/docs/pro-rata-collateral-snapshots.md
@@ -1,0 +1,69 @@
+# Pro-rata collateral release snapshots
+
+This note sketches a prototype for physical-style collateral release after a Wildcat market default
+or settlement trigger. Instead of forcing collateral through an AMM, a distributor releases the
+collateral asset itself to debt holders by their agreed share of the debt at a snapshot point.
+
+The prototype is intentionally narrow:
+
+- it does not change Wildcat market-token ERC-20 behaviour;
+- it does not claim onchain access to historical balances;
+- it does not build a liquidation router; and
+- it treats the reconciled snapshot as an authenticated input with a delay, not as magic.
+
+The full study is in [pro-rata-collateral-study.md](fiat/pro-rata-collateral-study.md). The delivery
+runbook is in [pro-rata-collateral-runbook.md](fiat/pro-rata-collateral-runbook.md).
+
+## Why this exists
+
+A BTC-backed USDC facility could want a default path where remaining BTC collateral is handed to
+debt holders pro rata. That avoids forced sale pressure and lets the credit document say, roughly:
+if the facility cannot be made good in USDC, the collateral is divided among the debt holders who
+owned the claim at the chosen point.
+
+That sounds simple until transfers, withdrawals and interest-bearing balances enter the picture.
+Wildcat market tokens expose user-facing balances through a scale factor, while the durable claim
+unit is the scaled balance. A clean release rule therefore needs a fixed snapshot of scaled debt,
+or an explicit decision to use another unit.
+
+## Chosen v0
+
+The first prototype is an attested Merkle snapshot distributor.
+
+1. A reconciler reconstructs debt-holder proportions for a market and snapshot point.
+2. A snapshot authority proposes a Merkle root, total scaled debt and evidence hash.
+3. The proposal waits through a review delay.
+4. The root is finalised.
+5. Each account claims collateral once with a Merkle proof.
+
+This is not trustless. The point of v0 is to make the trust boundary small and visible. A later
+version can replace the reconciler with a stronger ratifier set, a tracker hook deployed from market
+inception, or a proof system.
+
+## Why not mutate the debt token
+
+Changing the market token to checkpoint every holder would put a specialised settlement feature in
+the middle of a standard ERC-20 surface. It would also make every transfer pay for a product that
+only some markets need. The prototype keeps the debt token plain and puts the extra accounting in a
+separate contract.
+
+## Why not use only ERC-20 events
+
+ERC-20 `Transfer` events are not enough for an interest-bearing Wildcat claim. They report normalised
+amounts, while proportional settlement is cleaner in scaled debt. Wildcat hooks can see scaled
+amounts during deposits, transfers and queued withdrawals, so a future tracker hook can improve the
+data trail without changing ERC-20 behaviour.
+
+## What the audit should stare at
+
+- bad roots redirecting collateral;
+- the gap between historical truth and onchain verification;
+- active balances versus unpaid withdrawal claims;
+- scaled debt versus normalised debt;
+- double claims;
+- rounding dust;
+- admin cancellation and finalisation timing; and
+- collateral rescue after commitment.
+
+The design is promising only if those risks stay explicit. If the product copy starts saying “the
+contract knows all historical holders”, it has gone off the rails.

--- a/src/ProRataCollateralDistributor.sol
+++ b/src/ProRataCollateralDistributor.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
+pragma solidity >=0.8.20;
+
+import {MerkleProof} from "openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
+
+import {IProRataCollateralDistributor} from "./interfaces/IProRataCollateralDistributor.sol";
+import {LibERC20} from "./libraries/LibERC20.sol";
+import {ReentrancyGuard} from "./ReentrancyGuard.sol";
+
+contract ProRataCollateralDistributor is IProRataCollateralDistributor, ReentrancyGuard {
+    using LibERC20 for address;
+
+    address public immutable collateralAsset;
+    address public immutable market;
+    address public immutable snapshotAuthority;
+    address public immutable dustRecipient;
+    uint256 public immutable reviewDelay;
+
+    SnapshotProposal public pendingSnapshot;
+
+    bool public finalized;
+    bool public dustSwept;
+
+    uint256 public snapshotBlock;
+    uint256 public totalScaledDebt;
+    uint256 public totalCollateral;
+    uint256 public totalClaimedScaledDebt;
+    uint256 public totalClaimedCollateral;
+
+    bytes32 public merkleRoot;
+    bytes32 public evidenceHash;
+
+    mapping(address account => bool claimed) public claimed;
+
+    modifier onlySnapshotAuthority() {
+        if (msg.sender != snapshotAuthority) {
+            revert CallerNotSnapshotAuthority();
+        }
+        _;
+    }
+
+    constructor(
+        address collateralAsset_,
+        address market_,
+        address snapshotAuthority_,
+        address dustRecipient_,
+        uint256 reviewDelay_
+    ) {
+        if (collateralAsset_ == address(0)) revert InvalidCollateralAsset();
+        if (market_ == address(0)) revert InvalidMarket();
+        if (snapshotAuthority_ == address(0)) {
+            revert InvalidSnapshotAuthority();
+        }
+        if (dustRecipient_ == address(0)) revert InvalidDustRecipient();
+        if (reviewDelay_ == 0) revert InvalidReviewDelay();
+
+        collateralAsset = collateralAsset_;
+        market = market_;
+        snapshotAuthority = snapshotAuthority_;
+        dustRecipient = dustRecipient_;
+        reviewDelay = reviewDelay_;
+    }
+
+    function proposeSnapshot(
+        address market_,
+        uint256 snapshotBlock_,
+        uint256 totalScaledDebt_,
+        bytes32 merkleRoot_,
+        bytes32 evidenceHash_,
+        uint256 reviewEndsAt_
+    ) external onlySnapshotAuthority {
+        if (finalized) revert SnapshotAlreadyFinalized();
+        if (pendingSnapshot.merkleRoot != bytes32(0)) {
+            revert SnapshotProposalActive();
+        }
+        if (market_ != market) revert InvalidMarket();
+        if (snapshotBlock_ == 0) revert InvalidSnapshotBlock();
+        if (totalScaledDebt_ == 0) revert InvalidTotalScaledDebt();
+        if (merkleRoot_ == bytes32(0)) revert InvalidMerkleRoot();
+        if (evidenceHash_ == bytes32(0)) revert InvalidEvidenceHash();
+        if (reviewEndsAt_ < block.timestamp + reviewDelay) {
+            revert InvalidReviewEnd();
+        }
+
+        pendingSnapshot = SnapshotProposal({
+            market: market_,
+            snapshotBlock: snapshotBlock_,
+            totalScaledDebt: totalScaledDebt_,
+            merkleRoot: merkleRoot_,
+            evidenceHash: evidenceHash_,
+            reviewEndsAt: reviewEndsAt_
+        });
+
+        emit SnapshotProposed(market_, snapshotBlock_, totalScaledDebt_, merkleRoot_, evidenceHash_, reviewEndsAt_);
+    }
+
+    function cancelSnapshot() external onlySnapshotAuthority {
+        SnapshotProposal memory proposal = pendingSnapshot;
+        if (proposal.merkleRoot == bytes32(0)) revert NoSnapshotProposal();
+
+        delete pendingSnapshot;
+
+        emit SnapshotCancelled(proposal.evidenceHash);
+    }
+
+    function finalizeSnapshot() external {
+        if (finalized) revert SnapshotAlreadyFinalized();
+
+        SnapshotProposal memory proposal = pendingSnapshot;
+        if (proposal.merkleRoot == bytes32(0)) revert NoSnapshotProposal();
+        if (block.timestamp < proposal.reviewEndsAt) {
+            revert ReviewPeriodActive();
+        }
+
+        finalized = true;
+        snapshotBlock = proposal.snapshotBlock;
+        totalScaledDebt = proposal.totalScaledDebt;
+        merkleRoot = proposal.merkleRoot;
+        evidenceHash = proposal.evidenceHash;
+        totalCollateral = collateralAsset.balanceOf(address(this));
+
+        delete pendingSnapshot;
+
+        emit SnapshotFinalized(market, snapshotBlock, totalScaledDebt, totalCollateral, merkleRoot, evidenceHash);
+    }
+
+    function claim(uint256 scaledDebt, bytes32[] calldata proof, address recipient)
+        external
+        nonReentrant
+        returns (uint256 collateralAmount)
+    {
+        if (!finalized) revert SnapshotNotFinalized();
+        if (recipient == address(0)) revert InvalidRecipient();
+        if (claimed[msg.sender]) revert AlreadyClaimed();
+
+        bytes32 leaf = _leafHash(msg.sender, scaledDebt);
+        if (!MerkleProof.verifyCalldata(proof, merkleRoot, leaf)) {
+            revert InvalidProof();
+        }
+
+        claimed[msg.sender] = true;
+        totalClaimedScaledDebt += scaledDebt;
+        collateralAmount = FixedPointMathLib.fullMulDiv(totalCollateral, scaledDebt, totalScaledDebt);
+        totalClaimedCollateral += collateralAmount;
+
+        collateralAsset.safeTransfer(recipient, collateralAmount);
+
+        emit Claimed(msg.sender, recipient, scaledDebt, collateralAmount);
+    }
+
+    function sweepDust() external nonReentrant returns (uint256 amount) {
+        if (!finalized) revert SnapshotNotFinalized();
+        if (dustSwept) revert DustAlreadySwept();
+        if (totalClaimedScaledDebt != totalScaledDebt) {
+            revert ClaimsIncomplete();
+        }
+
+        dustSwept = true;
+        amount = collateralAsset.balanceOf(address(this));
+
+        if (amount != 0) {
+            collateralAsset.safeTransfer(dustRecipient, amount);
+        }
+
+        emit DustSwept(dustRecipient, amount);
+    }
+
+    function leafHash(address account, uint256 scaledDebt) external pure returns (bytes32) {
+        return _leafHash(account, scaledDebt);
+    }
+
+    function _leafHash(address account, uint256 scaledDebt) internal pure returns (bytes32) {
+        return keccak256(bytes.concat(keccak256(abi.encode(account, scaledDebt))));
+    }
+}

--- a/src/ProRataCollateralDistributor.sol
+++ b/src/ProRataCollateralDistributor.sol
@@ -66,6 +66,7 @@ contract ProRataCollateralDistributor is IProRataCollateralDistributor, Reentran
         address market_,
         uint256 snapshotBlock_,
         uint256 totalScaledDebt_,
+        uint256 collateralAmount_,
         bytes32 merkleRoot_,
         bytes32 evidenceHash_,
         uint256 reviewEndsAt_
@@ -77,6 +78,7 @@ contract ProRataCollateralDistributor is IProRataCollateralDistributor, Reentran
         if (market_ != market) revert InvalidMarket();
         if (snapshotBlock_ == 0) revert InvalidSnapshotBlock();
         if (totalScaledDebt_ == 0) revert InvalidTotalScaledDebt();
+        if (collateralAmount_ == 0) revert InvalidCollateralAmount();
         if (merkleRoot_ == bytes32(0)) revert InvalidMerkleRoot();
         if (evidenceHash_ == bytes32(0)) revert InvalidEvidenceHash();
         if (reviewEndsAt_ < block.timestamp + reviewDelay) {
@@ -87,12 +89,15 @@ contract ProRataCollateralDistributor is IProRataCollateralDistributor, Reentran
             market: market_,
             snapshotBlock: snapshotBlock_,
             totalScaledDebt: totalScaledDebt_,
+            collateralAmount: collateralAmount_,
             merkleRoot: merkleRoot_,
             evidenceHash: evidenceHash_,
             reviewEndsAt: reviewEndsAt_
         });
 
-        emit SnapshotProposed(market_, snapshotBlock_, totalScaledDebt_, merkleRoot_, evidenceHash_, reviewEndsAt_);
+        emit SnapshotProposed(
+            market_, snapshotBlock_, totalScaledDebt_, collateralAmount_, merkleRoot_, evidenceHash_, reviewEndsAt_
+        );
     }
 
     function cancelSnapshot() external onlySnapshotAuthority {
@@ -104,7 +109,7 @@ contract ProRataCollateralDistributor is IProRataCollateralDistributor, Reentran
         emit SnapshotCancelled(proposal.evidenceHash);
     }
 
-    function finalizeSnapshot() external {
+    function finalizeSnapshot() external onlySnapshotAuthority {
         if (finalized) revert SnapshotAlreadyFinalized();
 
         SnapshotProposal memory proposal = pendingSnapshot;
@@ -113,12 +118,17 @@ contract ProRataCollateralDistributor is IProRataCollateralDistributor, Reentran
             revert ReviewPeriodActive();
         }
 
+        uint256 balance = collateralAsset.balanceOf(address(this));
+        if (balance < proposal.collateralAmount) {
+            revert InsufficientCollateral();
+        }
+
         finalized = true;
         snapshotBlock = proposal.snapshotBlock;
         totalScaledDebt = proposal.totalScaledDebt;
         merkleRoot = proposal.merkleRoot;
         evidenceHash = proposal.evidenceHash;
-        totalCollateral = collateralAsset.balanceOf(address(this));
+        totalCollateral = proposal.collateralAmount;
 
         delete pendingSnapshot;
 

--- a/src/interfaces/IProRataCollateralDistributor.sol
+++ b/src/interfaces/IProRataCollateralDistributor.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
+pragma solidity >=0.8.20;
+
+interface IProRataCollateralDistributor {
+    struct SnapshotProposal {
+        address market;
+        uint256 snapshotBlock;
+        uint256 totalScaledDebt;
+        bytes32 merkleRoot;
+        bytes32 evidenceHash;
+        uint256 reviewEndsAt;
+    }
+
+    event SnapshotProposed(
+        address indexed market,
+        uint256 indexed snapshotBlock,
+        uint256 totalScaledDebt,
+        bytes32 merkleRoot,
+        bytes32 evidenceHash,
+        uint256 reviewEndsAt
+    );
+
+    event SnapshotCancelled(bytes32 indexed evidenceHash);
+
+    event SnapshotFinalized(
+        address indexed market,
+        uint256 indexed snapshotBlock,
+        uint256 totalScaledDebt,
+        uint256 totalCollateral,
+        bytes32 merkleRoot,
+        bytes32 evidenceHash
+    );
+
+    event Claimed(address indexed account, address indexed recipient, uint256 scaledDebt, uint256 collateralAmount);
+
+    event DustSwept(address indexed recipient, uint256 amount);
+
+    error CallerNotSnapshotAuthority();
+    error InvalidCollateralAsset();
+    error InvalidMarket();
+    error InvalidSnapshotAuthority();
+    error InvalidDustRecipient();
+    error InvalidReviewDelay();
+    error InvalidSnapshotBlock();
+    error InvalidTotalScaledDebt();
+    error InvalidMerkleRoot();
+    error InvalidEvidenceHash();
+    error InvalidReviewEnd();
+    error SnapshotAlreadyFinalized();
+    error SnapshotNotFinalized();
+    error SnapshotProposalActive();
+    error NoSnapshotProposal();
+    error ReviewPeriodActive();
+    error InvalidProof();
+    error AlreadyClaimed();
+    error InvalidRecipient();
+    error ClaimsIncomplete();
+    error DustAlreadySwept();
+
+    function proposeSnapshot(
+        address market,
+        uint256 snapshotBlock,
+        uint256 totalScaledDebt,
+        bytes32 merkleRoot,
+        bytes32 evidenceHash,
+        uint256 reviewEndsAt
+    ) external;
+
+    function cancelSnapshot() external;
+
+    function finalizeSnapshot() external;
+
+    function claim(uint256 scaledDebt, bytes32[] calldata proof, address recipient)
+        external
+        returns (uint256 collateralAmount);
+
+    function sweepDust() external returns (uint256 amount);
+
+    function leafHash(address account, uint256 scaledDebt) external pure returns (bytes32);
+}

--- a/src/interfaces/IProRataCollateralDistributor.sol
+++ b/src/interfaces/IProRataCollateralDistributor.sol
@@ -6,6 +6,7 @@ interface IProRataCollateralDistributor {
         address market;
         uint256 snapshotBlock;
         uint256 totalScaledDebt;
+        uint256 collateralAmount;
         bytes32 merkleRoot;
         bytes32 evidenceHash;
         uint256 reviewEndsAt;
@@ -15,6 +16,7 @@ interface IProRataCollateralDistributor {
         address indexed market,
         uint256 indexed snapshotBlock,
         uint256 totalScaledDebt,
+        uint256 collateralAmount,
         bytes32 merkleRoot,
         bytes32 evidenceHash,
         uint256 reviewEndsAt
@@ -43,9 +45,11 @@ interface IProRataCollateralDistributor {
     error InvalidReviewDelay();
     error InvalidSnapshotBlock();
     error InvalidTotalScaledDebt();
+    error InvalidCollateralAmount();
     error InvalidMerkleRoot();
     error InvalidEvidenceHash();
     error InvalidReviewEnd();
+    error InsufficientCollateral();
     error SnapshotAlreadyFinalized();
     error SnapshotNotFinalized();
     error SnapshotProposalActive();
@@ -61,6 +65,7 @@ interface IProRataCollateralDistributor {
         address market,
         uint256 snapshotBlock,
         uint256 totalScaledDebt,
+        uint256 collateralAmount,
         bytes32 merkleRoot,
         bytes32 evidenceHash,
         uint256 reviewEndsAt

--- a/test/ProRataCollateralDistributor.t.sol
+++ b/test/ProRataCollateralDistributor.t.sol
@@ -48,33 +48,37 @@ contract ProRataCollateralDistributorTest is Test {
         uint256 reviewEndsAt = block.timestamp + reviewDelay;
 
         vm.expectRevert(IProRataCollateralDistributor.CallerNotSnapshotAuthority.selector);
-        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt);
+        distributor.proposeSnapshot(market, block.number, 1 ether, 10 ether, root, evidence, reviewEndsAt);
 
         vm.startPrank(authority);
         vm.expectRevert(IProRataCollateralDistributor.InvalidMarket.selector);
-        distributor.proposeSnapshot(address(0xBEEF), block.number, 1 ether, root, evidence, reviewEndsAt);
+        distributor.proposeSnapshot(address(0xBEEF), block.number, 1 ether, 10 ether, root, evidence, reviewEndsAt);
 
         vm.expectRevert(IProRataCollateralDistributor.InvalidSnapshotBlock.selector);
-        distributor.proposeSnapshot(market, 0, 1 ether, root, evidence, reviewEndsAt);
+        distributor.proposeSnapshot(market, 0, 1 ether, 10 ether, root, evidence, reviewEndsAt);
 
         vm.expectRevert(IProRataCollateralDistributor.InvalidTotalScaledDebt.selector);
-        distributor.proposeSnapshot(market, block.number, 0, root, evidence, reviewEndsAt);
+        distributor.proposeSnapshot(market, block.number, 0, 10 ether, root, evidence, reviewEndsAt);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidCollateralAmount.selector);
+        distributor.proposeSnapshot(market, block.number, 1 ether, 0, root, evidence, reviewEndsAt);
 
         vm.expectRevert(IProRataCollateralDistributor.InvalidMerkleRoot.selector);
-        distributor.proposeSnapshot(market, block.number, 1 ether, bytes32(0), evidence, reviewEndsAt);
+        distributor.proposeSnapshot(market, block.number, 1 ether, 10 ether, bytes32(0), evidence, reviewEndsAt);
 
         vm.expectRevert(IProRataCollateralDistributor.InvalidEvidenceHash.selector);
-        distributor.proposeSnapshot(market, block.number, 1 ether, root, bytes32(0), reviewEndsAt);
+        distributor.proposeSnapshot(market, block.number, 1 ether, 10 ether, root, bytes32(0), reviewEndsAt);
 
         vm.expectRevert(IProRataCollateralDistributor.InvalidReviewEnd.selector);
-        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt - 1);
+        distributor.proposeSnapshot(market, block.number, 1 ether, 10 ether, root, evidence, reviewEndsAt - 1);
 
-        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt);
+        distributor.proposeSnapshot(market, block.number, 1 ether, 10 ether, root, evidence, reviewEndsAt);
 
         (
             address storedMarket,
             uint256 storedSnapshotBlock,
             uint256 storedTotalScaledDebt,
+            uint256 storedCollateralAmount,
             bytes32 storedRoot,
             bytes32 storedEvidence,
             uint256 storedReviewEndsAt
@@ -83,22 +87,23 @@ contract ProRataCollateralDistributorTest is Test {
         assertEq(storedMarket, market);
         assertEq(storedSnapshotBlock, block.number);
         assertEq(storedTotalScaledDebt, 1 ether);
+        assertEq(storedCollateralAmount, 10 ether);
         assertEq(storedRoot, root);
         assertEq(storedEvidence, evidence);
         assertEq(storedReviewEndsAt, reviewEndsAt);
 
         vm.expectRevert(IProRataCollateralDistributor.SnapshotProposalActive.selector);
-        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt);
+        distributor.proposeSnapshot(market, block.number, 1 ether, 10 ether, root, evidence, reviewEndsAt);
         vm.stopPrank();
     }
 
     function testCancelProposal() public {
-        _propose(_leaf(alice, 1 ether), 1 ether);
+        _propose(_leaf(alice, 1 ether), 1 ether, 1 ether);
 
         vm.prank(authority);
         distributor.cancelSnapshot();
 
-        (,,, bytes32 storedRoot,,) = distributor.pendingSnapshot();
+        (,,,, bytes32 storedRoot,,) = distributor.pendingSnapshot();
         assertEq(storedRoot, bytes32(0));
 
         vm.prank(authority);
@@ -108,13 +113,18 @@ contract ProRataCollateralDistributorTest is Test {
 
     function testFinalizeRequiresDelayAndCapturesCollateral() public {
         bytes32 root = _leaf(alice, 1 ether);
-        _propose(root, 1 ether);
+        _propose(root, 1 ether, 10 ether);
         collateralAsset.mint(address(distributor), 10 ether);
 
+        vm.prank(authority);
         vm.expectRevert(IProRataCollateralDistributor.ReviewPeriodActive.selector);
         distributor.finalizeSnapshot();
 
         vm.warp(block.timestamp + reviewDelay);
+        vm.expectRevert(IProRataCollateralDistributor.CallerNotSnapshotAuthority.selector);
+        distributor.finalizeSnapshot();
+
+        vm.prank(authority);
         distributor.finalizeSnapshot();
 
         assertTrue(distributor.finalized());
@@ -122,16 +132,35 @@ contract ProRataCollateralDistributorTest is Test {
         assertEq(distributor.totalScaledDebt(), 1 ether);
         assertEq(distributor.totalCollateral(), 10 ether);
 
+        vm.prank(authority);
         vm.expectRevert(IProRataCollateralDistributor.SnapshotAlreadyFinalized.selector);
         distributor.finalizeSnapshot();
+    }
+
+    function testFinalizeRequiresExpectedCollateralBalance() public {
+        _propose(_leaf(alice, 1 ether), 1 ether, 10 ether);
+        collateralAsset.mint(address(distributor), 9 ether);
+        vm.warp(block.timestamp + reviewDelay);
+
+        vm.prank(authority);
+        vm.expectRevert(IProRataCollateralDistributor.InsufficientCollateral.selector);
+        distributor.finalizeSnapshot();
+
+        collateralAsset.mint(address(distributor), 1 ether);
+
+        vm.prank(authority);
+        distributor.finalizeSnapshot();
+
+        assertEq(distributor.totalCollateral(), 10 ether);
     }
 
     function testRejectsBadProof() public {
         bytes32 aliceLeaf = _leaf(alice, 1 ether);
         bytes32 bobLeaf = _leaf(bob, 1 ether);
-        _propose(_root2(aliceLeaf, bobLeaf), 2 ether);
+        _propose(_root2(aliceLeaf, bobLeaf), 2 ether, 100 ether);
         collateralAsset.mint(address(distributor), 100 ether);
         vm.warp(block.timestamp + reviewDelay);
+        vm.prank(authority);
         distributor.finalizeSnapshot();
 
         bytes32[] memory badProof = new bytes32[](1);
@@ -145,9 +174,10 @@ contract ProRataCollateralDistributorTest is Test {
     function testClaimsProRataAndRejectsDoubleClaim() public {
         bytes32 aliceLeaf = _leaf(alice, 1 ether);
         bytes32 bobLeaf = _leaf(bob, 3 ether);
-        _propose(_root2(aliceLeaf, bobLeaf), 4 ether);
+        _propose(_root2(aliceLeaf, bobLeaf), 4 ether, 1000 ether);
         collateralAsset.mint(address(distributor), 1000 ether);
         vm.warp(block.timestamp + reviewDelay);
+        vm.prank(authority);
         distributor.finalizeSnapshot();
 
         bytes32[] memory aliceProof = new bytes32[](1);
@@ -178,9 +208,10 @@ contract ProRataCollateralDistributorTest is Test {
         bytes32 carolLeaf = _leaf(carol, 1);
         bytes32 pair = _hashPair(aliceLeaf, bobLeaf);
 
-        _propose(_hashPair(pair, carolLeaf), 3);
+        _propose(_hashPair(pair, carolLeaf), 3, 100);
         collateralAsset.mint(address(distributor), 100);
         vm.warp(block.timestamp + reviewDelay);
+        vm.prank(authority);
         distributor.finalizeSnapshot();
 
         bytes32[] memory aliceProof = new bytes32[](2);
@@ -214,7 +245,7 @@ contract ProRataCollateralDistributorTest is Test {
 
     function testClaimRequiresFinalizedSnapshotAndRecipient() public {
         bytes32 leaf = _leaf(alice, 1 ether);
-        _propose(leaf, 1 ether);
+        _propose(leaf, 1 ether, 1 ether);
 
         bytes32[] memory proof = new bytes32[](0);
         vm.prank(alice);
@@ -223,6 +254,7 @@ contract ProRataCollateralDistributorTest is Test {
 
         collateralAsset.mint(address(distributor), 1 ether);
         vm.warp(block.timestamp + reviewDelay);
+        vm.prank(authority);
         distributor.finalizeSnapshot();
 
         vm.prank(alice);
@@ -230,10 +262,16 @@ contract ProRataCollateralDistributorTest is Test {
         distributor.claim(1 ether, proof, address(0));
     }
 
-    function _propose(bytes32 root, uint256 totalScaledDebt) internal {
+    function _propose(bytes32 root, uint256 totalScaledDebt, uint256 collateralAmount) internal {
         vm.prank(authority);
         distributor.proposeSnapshot(
-            market, block.number, totalScaledDebt, root, keccak256("evidence"), block.timestamp + reviewDelay
+            market,
+            block.number,
+            totalScaledDebt,
+            collateralAmount,
+            root,
+            keccak256("evidence"),
+            block.timestamp + reviewDelay
         );
     }
 

--- a/test/ProRataCollateralDistributor.t.sol
+++ b/test/ProRataCollateralDistributor.t.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.20;
+
+import "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+
+import {ProRataCollateralDistributor} from "src/ProRataCollateralDistributor.sol";
+import {IProRataCollateralDistributor} from "src/interfaces/IProRataCollateralDistributor.sol";
+
+contract ProRataCollateralDistributorTest is Test {
+    MockERC20 collateralAsset;
+    ProRataCollateralDistributor distributor;
+
+    address market = address(0x1234);
+    address authority = address(0xA11CE);
+    address dustRecipient = address(0xD057);
+    address alice = address(0xA);
+    address bob = address(0xB);
+    address carol = address(0xC);
+    uint256 reviewDelay = 1 days;
+
+    function setUp() public {
+        collateralAsset = new MockERC20("Wrapped Bitcoin", "WBTC", 8);
+        distributor =
+            new ProRataCollateralDistributor(address(collateralAsset), market, authority, dustRecipient, reviewDelay);
+    }
+
+    function testConstructorValidation() public {
+        vm.expectRevert(IProRataCollateralDistributor.InvalidCollateralAsset.selector);
+        new ProRataCollateralDistributor(address(0), market, authority, dustRecipient, reviewDelay);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidMarket.selector);
+        new ProRataCollateralDistributor(address(collateralAsset), address(0), authority, dustRecipient, reviewDelay);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidSnapshotAuthority.selector);
+        new ProRataCollateralDistributor(address(collateralAsset), market, address(0), dustRecipient, reviewDelay);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidDustRecipient.selector);
+        new ProRataCollateralDistributor(address(collateralAsset), market, authority, address(0), reviewDelay);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidReviewDelay.selector);
+        new ProRataCollateralDistributor(address(collateralAsset), market, authority, dustRecipient, 0);
+    }
+
+    function testProposalValidationAndStorage() public {
+        bytes32 root = _leaf(alice, 1 ether);
+        bytes32 evidence = keccak256("evidence");
+        uint256 reviewEndsAt = block.timestamp + reviewDelay;
+
+        vm.expectRevert(IProRataCollateralDistributor.CallerNotSnapshotAuthority.selector);
+        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt);
+
+        vm.startPrank(authority);
+        vm.expectRevert(IProRataCollateralDistributor.InvalidMarket.selector);
+        distributor.proposeSnapshot(address(0xBEEF), block.number, 1 ether, root, evidence, reviewEndsAt);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidSnapshotBlock.selector);
+        distributor.proposeSnapshot(market, 0, 1 ether, root, evidence, reviewEndsAt);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidTotalScaledDebt.selector);
+        distributor.proposeSnapshot(market, block.number, 0, root, evidence, reviewEndsAt);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidMerkleRoot.selector);
+        distributor.proposeSnapshot(market, block.number, 1 ether, bytes32(0), evidence, reviewEndsAt);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidEvidenceHash.selector);
+        distributor.proposeSnapshot(market, block.number, 1 ether, root, bytes32(0), reviewEndsAt);
+
+        vm.expectRevert(IProRataCollateralDistributor.InvalidReviewEnd.selector);
+        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt - 1);
+
+        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt);
+
+        (
+            address storedMarket,
+            uint256 storedSnapshotBlock,
+            uint256 storedTotalScaledDebt,
+            bytes32 storedRoot,
+            bytes32 storedEvidence,
+            uint256 storedReviewEndsAt
+        ) = distributor.pendingSnapshot();
+
+        assertEq(storedMarket, market);
+        assertEq(storedSnapshotBlock, block.number);
+        assertEq(storedTotalScaledDebt, 1 ether);
+        assertEq(storedRoot, root);
+        assertEq(storedEvidence, evidence);
+        assertEq(storedReviewEndsAt, reviewEndsAt);
+
+        vm.expectRevert(IProRataCollateralDistributor.SnapshotProposalActive.selector);
+        distributor.proposeSnapshot(market, block.number, 1 ether, root, evidence, reviewEndsAt);
+        vm.stopPrank();
+    }
+
+    function testCancelProposal() public {
+        _propose(_leaf(alice, 1 ether), 1 ether);
+
+        vm.prank(authority);
+        distributor.cancelSnapshot();
+
+        (,,, bytes32 storedRoot,,) = distributor.pendingSnapshot();
+        assertEq(storedRoot, bytes32(0));
+
+        vm.prank(authority);
+        vm.expectRevert(IProRataCollateralDistributor.NoSnapshotProposal.selector);
+        distributor.cancelSnapshot();
+    }
+
+    function testFinalizeRequiresDelayAndCapturesCollateral() public {
+        bytes32 root = _leaf(alice, 1 ether);
+        _propose(root, 1 ether);
+        collateralAsset.mint(address(distributor), 10 ether);
+
+        vm.expectRevert(IProRataCollateralDistributor.ReviewPeriodActive.selector);
+        distributor.finalizeSnapshot();
+
+        vm.warp(block.timestamp + reviewDelay);
+        distributor.finalizeSnapshot();
+
+        assertTrue(distributor.finalized());
+        assertEq(distributor.merkleRoot(), root);
+        assertEq(distributor.totalScaledDebt(), 1 ether);
+        assertEq(distributor.totalCollateral(), 10 ether);
+
+        vm.expectRevert(IProRataCollateralDistributor.SnapshotAlreadyFinalized.selector);
+        distributor.finalizeSnapshot();
+    }
+
+    function testRejectsBadProof() public {
+        bytes32 aliceLeaf = _leaf(alice, 1 ether);
+        bytes32 bobLeaf = _leaf(bob, 1 ether);
+        _propose(_root2(aliceLeaf, bobLeaf), 2 ether);
+        collateralAsset.mint(address(distributor), 100 ether);
+        vm.warp(block.timestamp + reviewDelay);
+        distributor.finalizeSnapshot();
+
+        bytes32[] memory badProof = new bytes32[](1);
+        badProof[0] = aliceLeaf;
+
+        vm.prank(alice);
+        vm.expectRevert(IProRataCollateralDistributor.InvalidProof.selector);
+        distributor.claim(1 ether, badProof, alice);
+    }
+
+    function testClaimsProRataAndRejectsDoubleClaim() public {
+        bytes32 aliceLeaf = _leaf(alice, 1 ether);
+        bytes32 bobLeaf = _leaf(bob, 3 ether);
+        _propose(_root2(aliceLeaf, bobLeaf), 4 ether);
+        collateralAsset.mint(address(distributor), 1000 ether);
+        vm.warp(block.timestamp + reviewDelay);
+        distributor.finalizeSnapshot();
+
+        bytes32[] memory aliceProof = new bytes32[](1);
+        aliceProof[0] = bobLeaf;
+        vm.prank(alice);
+        uint256 aliceClaim = distributor.claim(1 ether, aliceProof, alice);
+        assertEq(aliceClaim, 250 ether);
+        assertEq(collateralAsset.balanceOf(alice), 250 ether);
+
+        vm.prank(alice);
+        vm.expectRevert(IProRataCollateralDistributor.AlreadyClaimed.selector);
+        distributor.claim(1 ether, aliceProof, alice);
+
+        bytes32[] memory bobProof = new bytes32[](1);
+        bobProof[0] = aliceLeaf;
+        vm.prank(bob);
+        uint256 bobClaim = distributor.claim(3 ether, bobProof, bob);
+        assertEq(bobClaim, 750 ether);
+        assertEq(collateralAsset.balanceOf(bob), 750 ether);
+
+        assertEq(distributor.totalClaimedScaledDebt(), 4 ether);
+        assertEq(distributor.totalClaimedCollateral(), 1000 ether);
+    }
+
+    function testDustCanOnlyBeSweptAfterAllScaledDebtClaims() public {
+        bytes32 aliceLeaf = _leaf(alice, 1);
+        bytes32 bobLeaf = _leaf(bob, 1);
+        bytes32 carolLeaf = _leaf(carol, 1);
+        bytes32 pair = _hashPair(aliceLeaf, bobLeaf);
+
+        _propose(_hashPair(pair, carolLeaf), 3);
+        collateralAsset.mint(address(distributor), 100);
+        vm.warp(block.timestamp + reviewDelay);
+        distributor.finalizeSnapshot();
+
+        bytes32[] memory aliceProof = new bytes32[](2);
+        aliceProof[0] = bobLeaf;
+        aliceProof[1] = carolLeaf;
+        vm.prank(alice);
+        assertEq(distributor.claim(1, aliceProof, alice), 33);
+
+        vm.expectRevert(IProRataCollateralDistributor.ClaimsIncomplete.selector);
+        distributor.sweepDust();
+
+        bytes32[] memory bobProof = new bytes32[](2);
+        bobProof[0] = aliceLeaf;
+        bobProof[1] = carolLeaf;
+        vm.prank(bob);
+        assertEq(distributor.claim(1, bobProof, bob), 33);
+
+        bytes32[] memory carolProof = new bytes32[](1);
+        carolProof[0] = pair;
+        vm.prank(carol);
+        assertEq(distributor.claim(1, carolProof, carol), 33);
+
+        assertEq(collateralAsset.balanceOf(address(distributor)), 1);
+
+        assertEq(distributor.sweepDust(), 1);
+        assertEq(collateralAsset.balanceOf(dustRecipient), 1);
+
+        vm.expectRevert(IProRataCollateralDistributor.DustAlreadySwept.selector);
+        distributor.sweepDust();
+    }
+
+    function testClaimRequiresFinalizedSnapshotAndRecipient() public {
+        bytes32 leaf = _leaf(alice, 1 ether);
+        _propose(leaf, 1 ether);
+
+        bytes32[] memory proof = new bytes32[](0);
+        vm.prank(alice);
+        vm.expectRevert(IProRataCollateralDistributor.SnapshotNotFinalized.selector);
+        distributor.claim(1 ether, proof, alice);
+
+        collateralAsset.mint(address(distributor), 1 ether);
+        vm.warp(block.timestamp + reviewDelay);
+        distributor.finalizeSnapshot();
+
+        vm.prank(alice);
+        vm.expectRevert(IProRataCollateralDistributor.InvalidRecipient.selector);
+        distributor.claim(1 ether, proof, address(0));
+    }
+
+    function _propose(bytes32 root, uint256 totalScaledDebt) internal {
+        vm.prank(authority);
+        distributor.proposeSnapshot(
+            market, block.number, totalScaledDebt, root, keccak256("evidence"), block.timestamp + reviewDelay
+        );
+    }
+
+    function _leaf(address account, uint256 scaledDebt) internal pure returns (bytes32) {
+        return keccak256(bytes.concat(keccak256(abi.encode(account, scaledDebt))));
+    }
+
+    function _root2(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        return _hashPair(a, b);
+    }
+
+    function _hashPair(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+    }
+}


### PR DESCRIPTION
## What changed

- Added `ProRataCollateralDistributor`, one market and one collateral asset per instance.
- Added `IProRataCollateralDistributor` with proposal, finalisation, claim and dust-sweep events.
- Added tests for constructor checks, proposal validation, cancellation, finalisation timing, underfunded finalisation, bad proofs, double claims, pro-rata payouts and dust.
- Updated the pro-rata snapshot docs so they match the hardened contract.

## Shape

The snapshot authority proposes `market`, `snapshotBlock`, `totalScaledDebt`, `collateralAmount`,
`merkleRoot`, `evidenceHash` and `reviewEndsAt`. After the review delay, the same authority can
finalise only if the distributor holds at least the committed collateral amount.

Claims use `floor(totalCollateral * scaledDebt / totalScaledDebt)`. Dust can move only after every
scaled-debt unit in the root has claimed.

## Audit

Round 1 found and fixed two issues:

- public finalisation could freeze an underfunded balance and push later collateral into dust;
- public finalisation could race an authority cancellation at the review deadline.

The fix commits the expected collateral amount in the proposal, makes finalisation authority-only,
checks funding before finalisation, and freezes `totalCollateral` from the committed amount.

## Validation

- `forge test --match-contract ProRataCollateralDistributorTest --summary`
- `forge test --summary`
- `git diff --check`
- `hexaemeron:imprimatur` on touched docs and audit log: 100/100

Stacks on #6. Tracks #5.

<!-- wildcat-origin: shoggoth -->
