### PR TITLE
feat: add debt snapshot recorder demo

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -35,3 +35,14 @@ Verification after fixes:
   authority/evidence-process risks: the root total must match the leaf sum, leaves are portable if an
   authority reuses a root in the wrong domain, and non-standard collateral tokens can still create
   operational accounting surprises.
+
+## Step 3, round 1 -- 2026-08-17
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| none | none | `src/DebtSnapshotEventRecorder.sol` / demo tests | The recorder is an event-only surface with no custody, stored balances or settlement authority. The only writer is the immutable `recorder` address, and invalid zero-account or zero-amount movements revert. No concrete exploit path was identified. | closed |
+
+Leads not pursued: the recorder can emit false data if the configured recorder is wrong or malicious,
+but that is the attestation boundary this prototype is meant to expose. The distributor still treats
+the reconciled Merkle root as the settlement input and enforces the review/funding/claim checks added
+in step 2. `forge test --summary` passed 51/51 after the demo was added.

--- a/docs/pro-rata-collateral-snapshots.md
+++ b/docs/pro-rata-collateral-snapshots.md
@@ -42,6 +42,17 @@ This is not trustless. The point of v0 is to make the trust boundary small and v
 version can replace the reconciler with a stronger ratifier set, a tracker hook deployed from market
 inception, or a proof system.
 
+## Event recorder prototype
+
+`DebtSnapshotEventRecorder` is the smallest useful observability surface. A designated recorder,
+standing in for a market hook or adapter, emits scaled debt movements for deposits, transfers and
+queued withdrawals. It does not store balances and it does not decide the settlement root. It gives a
+reconciler a clean event trail to check before proposing a root to the distributor.
+
+The lag is deliberate. The path is: emit movement events, reconcile offchain, propose the root, wait
+through the review delay, finalise the funded snapshot, then let holders claim. If the product needs
+same-block physical settlement, this design is the wrong tool.
+
 ## Why not mutate the debt token
 
 Changing the market token to checkpoint every holder would put a specialised settlement feature in

--- a/src/DebtSnapshotEventRecorder.sol
+++ b/src/DebtSnapshotEventRecorder.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
+pragma solidity >=0.8.20;
+
+import {IDebtSnapshotEventRecorder} from "./interfaces/IDebtSnapshotEventRecorder.sol";
+
+contract DebtSnapshotEventRecorder is IDebtSnapshotEventRecorder {
+    address public immutable market;
+    address public immutable recorder;
+
+    modifier onlyRecorder() {
+        if (msg.sender != recorder) revert CallerNotRecorder();
+        _;
+    }
+
+    constructor(address market_, address recorder_) {
+        if (market_ == address(0)) revert InvalidMarket();
+        if (recorder_ == address(0)) revert InvalidRecorder();
+
+        market = market_;
+        recorder = recorder_;
+    }
+
+    function recordDeposit(address account, uint256 scaledAmount) external onlyRecorder {
+        if (account == address(0)) revert InvalidAccount();
+        if (scaledAmount == 0) revert InvalidScaledAmount();
+
+        emit ScaledDebtMovement(market, address(0), account, scaledAmount, MovementKind.Deposit);
+    }
+
+    function recordTransfer(address from, address to, uint256 scaledAmount) external onlyRecorder {
+        if (from == address(0) || to == address(0)) revert InvalidTransfer();
+        if (from == to) revert InvalidTransfer();
+        if (scaledAmount == 0) revert InvalidScaledAmount();
+
+        emit ScaledDebtMovement(market, from, to, scaledAmount, MovementKind.Transfer);
+    }
+
+    function recordQueuedWithdrawal(address account, uint256 scaledAmount) external onlyRecorder {
+        if (account == address(0)) revert InvalidAccount();
+        if (scaledAmount == 0) revert InvalidScaledAmount();
+
+        emit ScaledDebtMovement(market, account, address(0), scaledAmount, MovementKind.QueueWithdrawal);
+    }
+}

--- a/src/interfaces/IDebtSnapshotEventRecorder.sol
+++ b/src/interfaces/IDebtSnapshotEventRecorder.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
+pragma solidity >=0.8.20;
+
+interface IDebtSnapshotEventRecorder {
+    enum MovementKind {
+        Deposit,
+        Transfer,
+        QueueWithdrawal
+    }
+
+    event ScaledDebtMovement(
+        address indexed market, address indexed from, address indexed to, uint256 scaledAmount, MovementKind kind
+    );
+
+    error InvalidMarket();
+    error InvalidRecorder();
+    error CallerNotRecorder();
+    error InvalidAccount();
+    error InvalidTransfer();
+    error InvalidScaledAmount();
+
+    function recordDeposit(address account, uint256 scaledAmount) external;
+
+    function recordTransfer(address from, address to, uint256 scaledAmount) external;
+
+    function recordQueuedWithdrawal(address account, uint256 scaledAmount) external;
+}

--- a/test/DebtSnapshotEventRecorder.t.sol
+++ b/test/DebtSnapshotEventRecorder.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.20;
+
+import "forge-std/Test.sol";
+
+import {DebtSnapshotEventRecorder} from "src/DebtSnapshotEventRecorder.sol";
+import {IDebtSnapshotEventRecorder} from "src/interfaces/IDebtSnapshotEventRecorder.sol";
+
+contract DebtSnapshotEventRecorderTest is Test {
+    DebtSnapshotEventRecorder recorder;
+
+    address market = address(0x1234);
+    address hook = address(0xB00C);
+    address alice = address(0xA);
+    address bob = address(0xB);
+
+    function setUp() public {
+        recorder = new DebtSnapshotEventRecorder(market, hook);
+    }
+
+    function testConstructorValidation() public {
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidMarket.selector);
+        new DebtSnapshotEventRecorder(address(0), hook);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidRecorder.selector);
+        new DebtSnapshotEventRecorder(market, address(0));
+    }
+
+    function testOnlyRecorderCanEmitMovements() public {
+        vm.expectRevert(IDebtSnapshotEventRecorder.CallerNotRecorder.selector);
+        recorder.recordDeposit(alice, 1);
+
+        vm.prank(hook);
+        recorder.recordDeposit(alice, 1);
+    }
+
+    function testRecordDeposit() public {
+        vm.expectEmit(true, true, true, true, address(recorder));
+        emit IDebtSnapshotEventRecorder.ScaledDebtMovement(
+            market, address(0), alice, 100, IDebtSnapshotEventRecorder.MovementKind.Deposit
+        );
+
+        vm.prank(hook);
+        recorder.recordDeposit(alice, 100);
+    }
+
+    function testRecordTransfer() public {
+        vm.expectEmit(true, true, true, true, address(recorder));
+        emit IDebtSnapshotEventRecorder.ScaledDebtMovement(
+            market, alice, bob, 40, IDebtSnapshotEventRecorder.MovementKind.Transfer
+        );
+
+        vm.prank(hook);
+        recorder.recordTransfer(alice, bob, 40);
+    }
+
+    function testRecordQueuedWithdrawal() public {
+        vm.expectEmit(true, true, true, true, address(recorder));
+        emit IDebtSnapshotEventRecorder.ScaledDebtMovement(
+            market, alice, address(0), 25, IDebtSnapshotEventRecorder.MovementKind.QueueWithdrawal
+        );
+
+        vm.prank(hook);
+        recorder.recordQueuedWithdrawal(alice, 25);
+    }
+
+    function testRejectsInvalidMovements() public {
+        vm.startPrank(hook);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidAccount.selector);
+        recorder.recordDeposit(address(0), 1);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidScaledAmount.selector);
+        recorder.recordDeposit(alice, 0);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidTransfer.selector);
+        recorder.recordTransfer(address(0), bob, 1);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidTransfer.selector);
+        recorder.recordTransfer(alice, alice, 1);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidScaledAmount.selector);
+        recorder.recordTransfer(alice, bob, 0);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidAccount.selector);
+        recorder.recordQueuedWithdrawal(address(0), 1);
+
+        vm.expectRevert(IDebtSnapshotEventRecorder.InvalidScaledAmount.selector);
+        recorder.recordQueuedWithdrawal(alice, 0);
+
+        vm.stopPrank();
+    }
+}

--- a/test/ProRataCollateralReleaseDemo.t.sol
+++ b/test/ProRataCollateralReleaseDemo.t.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.20;
+
+import "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+
+import {DebtSnapshotEventRecorder} from "src/DebtSnapshotEventRecorder.sol";
+import {IDebtSnapshotEventRecorder} from "src/interfaces/IDebtSnapshotEventRecorder.sol";
+import {ProRataCollateralDistributor} from "src/ProRataCollateralDistributor.sol";
+
+contract ProRataCollateralReleaseDemoTest is Test {
+    MockERC20 collateralAsset;
+    DebtSnapshotEventRecorder recorder;
+    ProRataCollateralDistributor distributor;
+
+    address market = address(0x1234);
+    address hook = address(0xB00C);
+    address authority = address(0xA11CE);
+    address dustRecipient = address(0xD057);
+    address alice = address(0xA);
+    address bob = address(0xB);
+    address carol = address(0xC);
+    uint256 reviewDelay = 1 days;
+
+    function setUp() public {
+        collateralAsset = new MockERC20("Wrapped Bitcoin", "WBTC", 8);
+        recorder = new DebtSnapshotEventRecorder(market, hook);
+        distributor =
+            new ProRataCollateralDistributor(address(collateralAsset), market, authority, dustRecipient, reviewDelay);
+    }
+
+    function testEndToEndCollateralReleaseFromReconciledEvents() public {
+        vm.recordLogs();
+
+        uint256 aliceScaledDebt;
+        uint256 bobScaledDebt;
+        uint256 carolScaledDebt;
+
+        vm.prank(hook);
+        recorder.recordDeposit(alice, 60);
+        aliceScaledDebt += 60;
+
+        vm.prank(hook);
+        recorder.recordDeposit(bob, 50);
+        bobScaledDebt += 50;
+
+        vm.prank(hook);
+        recorder.recordTransfer(alice, carol, 20);
+        aliceScaledDebt -= 20;
+        carolScaledDebt += 20;
+
+        vm.prank(hook);
+        recorder.recordQueuedWithdrawal(bob, 10);
+        bobScaledDebt -= 10;
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries.length, 4);
+        assertEq(entries[0].topics[0], IDebtSnapshotEventRecorder.ScaledDebtMovement.selector);
+
+        uint256 snapshotBlock = block.number;
+        uint256 totalScaledDebt = aliceScaledDebt + bobScaledDebt + carolScaledDebt;
+        uint256 collateralAmount = 100 ether;
+
+        bytes32 aliceLeaf = _leaf(alice, aliceScaledDebt);
+        bytes32 bobLeaf = _leaf(bob, bobScaledDebt);
+        bytes32 carolLeaf = _leaf(carol, carolScaledDebt);
+        bytes32 pair = _hashPair(aliceLeaf, bobLeaf);
+        bytes32 root = _hashPair(pair, carolLeaf);
+
+        collateralAsset.mint(address(distributor), collateralAmount);
+
+        vm.prank(authority);
+        distributor.proposeSnapshot(
+            market,
+            snapshotBlock,
+            totalScaledDebt,
+            collateralAmount,
+            root,
+            keccak256("reconciled event bundle"),
+            block.timestamp + reviewDelay
+        );
+
+        vm.warp(block.timestamp + reviewDelay);
+
+        vm.prank(authority);
+        distributor.finalizeSnapshot();
+
+        bytes32[] memory aliceProof = new bytes32[](2);
+        aliceProof[0] = bobLeaf;
+        aliceProof[1] = carolLeaf;
+        vm.prank(alice);
+        assertEq(distributor.claim(aliceScaledDebt, aliceProof, alice), 40 ether);
+
+        bytes32[] memory bobProof = new bytes32[](2);
+        bobProof[0] = aliceLeaf;
+        bobProof[1] = carolLeaf;
+        vm.prank(bob);
+        assertEq(distributor.claim(bobScaledDebt, bobProof, bob), 40 ether);
+
+        bytes32[] memory carolProof = new bytes32[](1);
+        carolProof[0] = pair;
+        vm.prank(carol);
+        assertEq(distributor.claim(carolScaledDebt, carolProof, carol), 20 ether);
+
+        assertEq(collateralAsset.balanceOf(alice), 40 ether);
+        assertEq(collateralAsset.balanceOf(bob), 40 ether);
+        assertEq(collateralAsset.balanceOf(carol), 20 ether);
+        assertEq(collateralAsset.balanceOf(address(distributor)), 0);
+    }
+
+    function _leaf(address account, uint256 scaledDebt) internal pure returns (bytes32) {
+        return keccak256(bytes.concat(keccak256(abi.encode(account, scaledDebt))));
+    }
+
+    function _hashPair(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+    }
+}


### PR DESCRIPTION
## What changed

- Added `DebtSnapshotEventRecorder`, an event-only surface for scaled debt movements.
- Added `IDebtSnapshotEventRecorder`.
- Added tests for recorder validation, write authority and emitted movement events.
- Added an end-to-end demo that records scaled movements, builds a reconciled Merkle root, finalises
  a funded distributor snapshot and releases collateral to three holders.
- Updated the pro-rata snapshot note with the event-trail and reconciliation lag.

## Shape

The recorder has no custody and no settlement authority. A configured recorder address emits
deposit, transfer and queued-withdrawal movements. A reconciler reads those events, proposes a root
to the distributor, waits through review, and then holders claim against the finalised root.

The demo uses 100 units of scaled debt and 100 collateral tokens: Alice ends at 40, Bob at 40 and
Carol at 20.

## Audit

Round 1 found no concrete exploit path. The remaining caveat is the point of the prototype: if the
configured recorder lies, the event trail lies. The distributor still treats the reconciled Merkle
root as the settlement input and enforces the step 2 review, funding and claim checks.

## Validation

- `forge test --match-contract 'DebtSnapshotEventRecorderTest|ProRataCollateralReleaseDemoTest' --summary`
- `forge test --summary`
- `git diff --check`
- `hexaemeron:imprimatur` on touched docs, audit log and PR body: 100/100

Stacks on #7. Tracks #5.

<!-- wildcat-origin: shoggoth -->
